### PR TITLE
Added missing LICENSE meta data

### DIFF
--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d4eff2a746f1634cb0f23e30750844f
+timeCreated: 1509715024
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Upon importing into Unity, LICENSE.meta will be generated as it is missing from remote