### PR TITLE
IOS Permissions Build Step

### DIFF
--- a/IOS.meta
+++ b/IOS.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6b49ea4c43b30254ba2b8e684bfd89ec
+folderAsset: yes
+timeCreated: 1510848841
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IOS/Editor.meta
+++ b/IOS/Editor.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 121dec728b4ebb544aa3b117cb8d98da
+folderAsset: yes
+timeCreated: 1510848841
+licenseType: Pro
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IOS/Editor/AddIOSPermissions.cs
+++ b/IOS/Editor/AddIOSPermissions.cs
@@ -13,12 +13,12 @@ namespace DUCK.IOS
 			if (buildTarget != BuildTarget.iOS) return;
 			
 			// Get plist
-			string plistPath = pathToBuiltProject + "/Info.plist";
-			PlistDocument plist = new PlistDocument();
+			var plistPath = pathToBuiltProject + "/Info.plist";
+			var plist = new PlistDocument();
 			plist.ReadFromString(File.ReadAllText(plistPath));
 
 			// Get root
-			PlistElementDict rootDict = plist.root;
+			var rootDict = plist.root;
 
 			var guids = AssetDatabase.FindAssets("t:IOSPermissionsObject");
 			foreach (string guid in guids)

--- a/IOS/Editor/AddIOSPermissions.cs
+++ b/IOS/Editor/AddIOSPermissions.cs
@@ -1,0 +1,39 @@
+﻿using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
+using System.IO;
+
+namespace DUCK.IOS
+{
+	public class AddIOSPermissions
+	{
+		[PostProcessBuild]
+		public static void ChangeXcodePlist(BuildTarget buildTarget, string pathToBuiltProject)
+		{
+			if (buildTarget == BuildTarget.iOS)
+			{
+				// Get plist
+				string plistPath = pathToBuiltProject + "/Info.plist";
+				PlistDocument plist = new PlistDocument();
+				plist.ReadFromString(File.ReadAllText(plistPath));
+
+				// Get root
+				PlistElementDict rootDict = plist.root;
+
+				var guids = AssetDatabase.FindAssets("t:IOSPermissionsObject");
+				foreach (string guid in guids)
+				{
+					var permissionsFile = AssetDatabase.LoadAssetAtPath<IOSPermissionsObject>(AssetDatabase.GUIDToAssetPath(guid));
+
+					foreach(var permission in permissionsFile.Permissions)
+					{
+						rootDict.SetString(permission.key, permission.value);
+					}
+				}
+
+				// Write to file
+				File.WriteAllText(plistPath, plist.WriteToString());
+			}
+		}
+	}
+}

--- a/IOS/Editor/AddIOSPermissions.cs
+++ b/IOS/Editor/AddIOSPermissions.cs
@@ -1,7 +1,8 @@
-﻿using UnityEditor;
+﻿using System;
+using System.IO;
+using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
-using System.IO;
 
 namespace DUCK.IOS
 {
@@ -27,7 +28,18 @@ namespace DUCK.IOS
 
 					foreach(var permission in permissionsFile.Permissions)
 					{
-						rootDict.SetString(permission.key, permission.value);
+						switch(permission.permissionType)
+						{
+							case PermissionVariableType.Boolean:
+								rootDict.SetBoolean(permission.key, bool.Parse(permission.value));
+								break;
+							case PermissionVariableType.String:
+								rootDict.SetString(permission.key, permission.value);
+								break;
+							case PermissionVariableType.Integer:
+								rootDict.SetInteger(permission.key, int.Parse(permission.value));
+								break;
+						}
 					}
 				}
 

--- a/IOS/Editor/AddIOSPermissions.cs.meta
+++ b/IOS/Editor/AddIOSPermissions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 8440adb4d2b9392479d8c3f0cc354329
+timeCreated: 1510848843
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IOS/Editor/CreateIOSPermissionObject.cs
+++ b/IOS/Editor/CreateIOSPermissionObject.cs
@@ -1,11 +1,12 @@
 ﻿using DUCK.Editor;
+using UnityEditor;
 
 namespace DUCK.IOS
 {
 	public class CreateIOSPermissionsObject
 	{
 		[MenuItem("Assets/Create/IOSPermissionsObject")]
-		public static void CreateIOSPermissionsObject()
+		public static void CreateScriptableObject()
 		{
 			ScriptableObjectUtility.CreateAsset<IOSPermissionsObject>();
 		}

--- a/IOS/Editor/CreateIOSPermissionObject.cs
+++ b/IOS/Editor/CreateIOSPermissionObject.cs
@@ -1,0 +1,13 @@
+﻿using DUCK.Editor;
+
+namespace DUCK.IOS
+{
+	public class CreateIOSPermissionsObject
+	{
+		[MenuItem("Assets/Create/IOSPermissionsObject")]
+		public static void CreateIOSPermissionsObject()
+		{
+			ScriptableObjectUtility.CreateAsset<IOSPermissionsObject>();
+		}
+	}
+}

--- a/IOS/Editor/CreateIOSPermissionObject.cs.meta
+++ b/IOS/Editor/CreateIOSPermissionObject.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: aab16e8b5a3ad2e419bfc0b4a1d20520
+timeCreated: 1510848843
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/IOS/IOSPermissionsObject.cs
+++ b/IOS/IOSPermissionsObject.cs
@@ -3,11 +3,19 @@ using UnityEngine;
 
 namespace DUCK.IOS
 {
+	public enum PermissionVariableType
+	{
+		String,
+		Integer,
+		Boolean,
+	}
+
 	[Serializable]
 	public class IOSPermission
 	{
 		public string key;
 		public string value;
+		public PermissionVariableType permissionType;
 	}
 
 	public class IOSPermissionsObject : ScriptableObject

--- a/IOS/IOSPermissionsObject.cs
+++ b/IOS/IOSPermissionsObject.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using UnityEngine;
+
+namespace DUCK.IOS
+{
+	[Serializable]
+	public class IOSPermission
+	{
+		public string key;
+		public string value;
+	}
+
+	public class IOSPermissionsObject : ScriptableObject
+	{
+		public IOSPermission[] Permissions { get { return permissions; } }
+
+		[SerializeField]
+		private IOSPermission[] permissions;
+	}
+}

--- a/IOS/IOSPermissionsObject.cs.meta
+++ b/IOS/IOSPermissionsObject.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 71a937cf12441844ea42bc457adae57f
+timeCreated: 1510848843
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Allows developers to create a file that injects IOS permissions into the info.plist file once the build is complete. This allows you to insert permissions like the camera or update default settings.

```
<key>NSCameraUsageDescription</key>
<string>Required to Scan QR codes</string>
```

**Currently not supported are arrays and dictionaries.**