### PR TITLE
Dev timed animation fix

### DIFF
--- a/Tween/AbstractAnimation.cs
+++ b/Tween/AbstractAnimation.cs
@@ -31,20 +31,14 @@ namespace DUCK.Tween
 		public abstract bool IsValid { get; }
 
 		private Action onCompleteCallback;
-
-		/// <summary>
-		/// Starts playback of the animation without any callbacks.
-		/// </summary>
-		public void Play()
-		{
-			Play(null);
-		}
+		private Action onAbortCallback;
 
 		/// <summary>
 		/// Starts playback of the animation
 		/// </summary>
 		/// <param name="onComplete">An optional callback invoked when the animation is complete</param>
-		public virtual void Play(Action onComplete)
+		/// <param name="onAbort">An optional callback invoked if the animation is aborted</param>
+		public virtual void Play(Action onComplete = null, Action onAbort = null)
 		{
 			if (!IsValid)
 			{
@@ -53,6 +47,7 @@ namespace DUCK.Tween
 			}
 
 			onCompleteCallback = onComplete;
+			onAbortCallback = onAbort;
 			IsPlaying = true;
 		}
 
@@ -62,7 +57,8 @@ namespace DUCK.Tween
 		/// <param name="repeat">The repeat times for the animation. 0 (or less than -1) means no repeat; -1 means infinite loop.</param>
 		/// <param name="onRepeat">An optional callback invoked on each repeat is complete</param>
 		/// <param name="onAllComplete">An optional callback invoked when all repeats are finished (will call once only)</param>
-		public void Play(int repeat, Action onRepeat = null, Action onAllComplete = null)
+		/// <param name="onAbort">An optional callback invoked if the animation is aborted</param>
+		public void Play(int repeat, Action onRepeat = null, Action onAllComplete = null, Action onAbort = null)
 		{
 			if (!IsValid)
 			{
@@ -81,7 +77,7 @@ namespace DUCK.Tween
 
 				if (IsLooping)
 				{
-					Play(repeat == -1 ? -1 : --repeat, onRepeat, onAllComplete);
+					Play(repeat == -1 ? -1 : --repeat, onRepeat, onAllComplete, onAbort);
 				}
 				// This will only occur when the user called FastForward().
 				// Abort an animation wouldn't get this delegate called anyway.
@@ -91,7 +87,7 @@ namespace DUCK.Tween
 				}
 			};
 
-			Play(IsLooping ? onRepeatComplete : onAllComplete);
+			Play(IsLooping ? onRepeatComplete : onAllComplete, onAbort);
 		}
 
 		/// <summary>
@@ -102,6 +98,11 @@ namespace DUCK.Tween
 			IsPlaying = false;
 			IsLooping = false;
 			IsPaused = false;
+
+			if (onAbortCallback != null)
+			{
+				onAbortCallback();
+			}
 		}
 
 		/// <summary>

--- a/Tween/AnimationCollection.cs
+++ b/Tween/AnimationCollection.cs
@@ -36,9 +36,10 @@ namespace DUCK.Tween
 		/// Starts playback of the AnimationCollection starting at the first animation
 		/// </summary>
 		/// <param name="onComplete">An optional callback invoked when the AnimationCollection is complete</param>
-		public override void Play(Action onComplete)
+		/// <param name="onAbort">An optional callback invoked if the AnimationCollection is aborted</param>
+		public override void Play(Action onComplete = null, Action onAbort = null)
 		{
-			base.Play(onComplete);
+			base.Play(onComplete, onAbort);
 			NumberOfAnimationsCompleted = 0;
 			PlayQueuedAnimations();
 		}

--- a/Tween/DelegateAnimation.cs
+++ b/Tween/DelegateAnimation.cs
@@ -32,20 +32,20 @@ namespace DUCK.Tween
 			this.animationCreationFunction = animationCreationFunction;
 		}
 
-		public override void Play(Action onComplete)
+		public override void Play(Action onComplete = null, Action onAbort = null)
 		{
-			base.Play(onComplete);
+			base.Play(onComplete, onAbort);
 
 			try
 			{
 				Animation = animationCreationFunction();
 				if (Animation.IsValid)
 				{
-					Animation.Play(NotifyAnimationComplete);
+					Animation.Play(NotifyAnimationComplete, base.Abort);
 				}
 				else
 				{
-					base.FastForward();
+					base.Abort();
 				}
 			}
 			catch (MissingReferenceException e)
@@ -67,7 +67,6 @@ namespace DUCK.Tween
 			{
 				Animation.Abort();
 			}
-			base.Abort();
 		}
 
 		public override void FastForward()

--- a/Tween/FunctionCallAnimation.cs
+++ b/Tween/FunctionCallAnimation.cs
@@ -28,9 +28,9 @@ namespace DUCK.Tween
 			this.action = action;
 		}
 
-		public override void Play(Action onComplete)
+		public override void Play(Action onComplete = null, Action onAbort = null)
 		{
-			base.Play(onComplete);
+			base.Play(onComplete, onAbort);
 			action();
 			// During the action() above, this animation may get aborted.
 			if (IsPlaying)

--- a/Tween/SequencedAnimation.cs
+++ b/Tween/SequencedAnimation.cs
@@ -25,14 +25,12 @@ namespace DUCK.Tween
 				{
 					nextAnimation.Play(() =>
 					{
-						if (!nextAnimation.IsValid)
-						{
-							Animations.Remove(nextAnimation);
-						}
-						else
-						{
-							NumberOfAnimationsCompleted++;
-						}
+						NumberOfAnimationsCompleted++;
+						PlayQueuedAnimations();
+					},
+					() =>
+					{
+						Animations.Remove(nextAnimation);
 						PlayQueuedAnimations();
 					});
 				}

--- a/Tween/TimedAnimation.cs
+++ b/Tween/TimedAnimation.cs
@@ -35,24 +35,12 @@ namespace DUCK.Tween
 
 		/// <summary>
 		/// The duration of the timed animation
-		/// When it sets to less or equal 0, it will act as FastForward.
+		/// Duration will always clamp to >= 0
 		/// </summary>
 		public float Duration
 		{
 			get { return duration; }
-			set
-			{
-				if (value <= 0)
-				{
-					Debug.LogError("Animation duration cannot set to zero!");
-					duration = 1.0f; // Make sure not divide by 0
-					FastForward();
-				}
-				else
-				{
-					duration = value;
-				}
-			}
+			set { duration = Mathf.Max(0, value); }
 		}
 		private float duration;
 

--- a/Tween/TimedAnimation.cs
+++ b/Tween/TimedAnimation.cs
@@ -56,8 +56,8 @@ namespace DUCK.Tween
 
 		public override bool IsValid { get { return TargetObject != null || TargetRectTransform != null; } }
 
-		protected bool IsComplete { get { return IsReversed ? Progress <= 0 : Progress >= 1.0f; } }
-		protected float Progress { get { return Mathf.Clamp01(CurrentTime / Duration); } }
+		protected bool IsComplete { get { return IsReversed ? Progress <= 0f : Progress >= 1.0f; } }
+		private float Progress { get { return Mathf.Clamp01(CurrentTime / Duration); } }
 
 		protected Func<float, float> easingFunction;
 
@@ -89,14 +89,24 @@ namespace DUCK.Tween
 				return;
 			}
 
-			// A little guard for unnecessary adding to the update list
-			if (!IsPlaying)
+			if (Duration > 0f)
 			{
-				AnimationDriver.Add(Update);
+				// A little guard for unnecessary adding to the update list
+				if (!IsPlaying)
+				{
+					AnimationDriver.Add(Update);
+				}
+
+				base.Play(onComplete);
+				Refresh(CurrentTime = IsReversed ? Duration : 0f);
+			}
+			else
+			{
+				base.Play(onComplete);
+				Refresh(1.0f);
+				NotifyAnimationComplete();
 			}
 
-			base.Play(onComplete);
-			Refresh(CurrentTime = IsReversed ? Duration : 0);
 		}
 
 		public override void Abort()

--- a/Tween/TimedAnimation.cs
+++ b/Tween/TimedAnimation.cs
@@ -56,10 +56,10 @@ namespace DUCK.Tween
 
 		public override bool IsValid { get { return TargetObject != null || TargetRectTransform != null; } }
 
-		protected bool IsComplete { get { return IsReversed ? Progress <= 0f : Progress >= 1f; } }
-		private float Progress { get { return Mathf.Clamp01(CurrentTime / Duration); } }
-
 		protected Func<float, float> easingFunction;
+
+		private bool IsComplete { get { return IsReversed ? Progress <= 0f : Progress >= 1f; } }
+		private float Progress { get { return Mathf.Clamp01(CurrentTime / Duration); } }
 
 		protected TimedAnimation() {}
 
@@ -102,6 +102,7 @@ namespace DUCK.Tween
 			}
 			else
 			{
+				// If the duration <= 0 we immediately finish the animation
 				base.Play(onComplete);
 				Refresh(1f);
 				NotifyAnimationComplete();

--- a/Tween/TimedAnimation.cs
+++ b/Tween/TimedAnimation.cs
@@ -40,7 +40,7 @@ namespace DUCK.Tween
 		public float Duration
 		{
 			get { return duration; }
-			set { duration = Mathf.Max(0, value); }
+			set { duration = Mathf.Max(0f, value); }
 		}
 		private float duration;
 
@@ -56,7 +56,7 @@ namespace DUCK.Tween
 
 		public override bool IsValid { get { return TargetObject != null || TargetRectTransform != null; } }
 
-		protected bool IsComplete { get { return IsReversed ? Progress <= 0f : Progress >= 1.0f; } }
+		protected bool IsComplete { get { return IsReversed ? Progress <= 0f : Progress >= 1f; } }
 		private float Progress { get { return Mathf.Clamp01(CurrentTime / Duration); } }
 
 		protected Func<float, float> easingFunction;
@@ -103,7 +103,7 @@ namespace DUCK.Tween
 			else
 			{
 				base.Play(onComplete);
-				Refresh(1.0f);
+				Refresh(1f);
 				NotifyAnimationComplete();
 			}
 

--- a/Tween/TimedAnimation.cs
+++ b/Tween/TimedAnimation.cs
@@ -81,7 +81,8 @@ namespace DUCK.Tween
 		/// Call it again (anytime) will simply replay the animation.
 		/// </summary>
 		/// <param name="onComplete">An optional callback invoked when the animation is complete</param>
-		public override void Play(Action onComplete)
+		/// <param name="onAbort">An optional callback invoked if the animation is aborted</param>
+		public override void Play(Action onComplete = null, Action onAbort = null)
 		{
 			if (!IsValid)
 			{
@@ -97,13 +98,13 @@ namespace DUCK.Tween
 					AnimationDriver.Add(Update);
 				}
 
-				base.Play(onComplete);
+				base.Play(onComplete, onAbort);
 				Refresh(CurrentTime = IsReversed ? Duration : 0f);
 			}
 			else
 			{
 				// If the duration <= 0 we immediately finish the animation
-				base.Play(onComplete);
+				base.Play(onComplete, onAbort);
 				Refresh(1f);
 				NotifyAnimationComplete();
 			}
@@ -167,7 +168,6 @@ namespace DUCK.Tween
 			{
 				CurrentTime = Duration;
 				Abort();
-				NotifyAnimationComplete();
 				return;
 			}
 


### PR DESCRIPTION
If a TimedAnimation was given a duration of <= 0 in the constructor, the Duration property setter called FastForward and invoked the OnComplete callback without having Play called.