### PR TITLE
Tween Serialization + Editor Support

### DIFF
--- a/Serialization/ArgsList.Serialization.cs
+++ b/Serialization/ArgsList.Serialization.cs
@@ -68,12 +68,12 @@ namespace DUCK.Serialization
 				{
 					var arg = args[i];
 					list.Add(arg);
-					typeOrderList.Add(COMPONENT_PREFIX + argType.Name);
+					typeOrderList.Add(COMPONENT_PREFIX + argType.FullName);
 				}
 				else
 				{
 					list.Add(args[i]);
-					typeOrderList.Add(argType.Name);
+					typeOrderList.Add(argType.FullName);
 				}
 			}
 
@@ -95,7 +95,7 @@ namespace DUCK.Serialization
 			foreach (var supportedType in supportedTypes.Values)
 			{
 				var list = supportedType.GetList(this);
-				serializedLists.Add(supportedType.Type.Name, list);
+				serializedLists.Add(supportedType.Type.FullName, list);
 			}
 
 			for (var i = 0; i < typeOrder.Length; i++)
@@ -117,7 +117,7 @@ namespace DUCK.Serialization
 
 					argType = componentTypes[typeName];
 					localArgTypes.Add(argType);
-					list = serializedLists[typeof(GameObject).Name];
+					list = serializedLists[typeof(GameObject).FullName];
 				}
 				else
 				{

--- a/Serialization/ArgsList.Serialization.cs
+++ b/Serialization/ArgsList.Serialization.cs
@@ -9,7 +9,7 @@ namespace DUCK.Serialization
 	public partial class ArgsList
 	{
 		private const string COMPONENT_PREFIX = "c:";
-		
+
 		[SerializeField]
 		private string[] typeOrder;
 
@@ -110,8 +110,6 @@ namespace DUCK.Serialization
 					typeName = typeName.Replace(COMPONENT_PREFIX, "");
 					if (!componentTypes.ContainsKey(typeName))
 					{
-						// TODO: How to handle this error (found a component type not in the assemblies on deserialize)
-						// for now let's throw, but we may want to handle it more elegantly
 						throw new Exception("ArgsList cannot deserialize component item of type: " + typeName + ", it was not found in the assemblies");
 					}
 

--- a/Serialization/ArgsList.cs
+++ b/Serialization/ArgsList.cs
@@ -56,7 +56,6 @@ namespace DUCK.Serialization
 				// (it can happen, since some types are shipped in multiple assemblies)
 				if (!componentTypes.ContainsKey(type.FullName))
 				{
-					Debug.Log(type.FullName);
 					componentTypes.Add(type.FullName, type);
 				}
 			}

--- a/Serialization/ArgsList.cs
+++ b/Serialization/ArgsList.cs
@@ -42,8 +42,11 @@ namespace DUCK.Serialization
 			// Get every type that extends component
 			var assemblies = new []
 			{
+				// Project assembly
 				Assembly.GetExecutingAssembly(),
+				// UnityEngine Assembly
 				typeof(Component).Assembly,
+				// UnityEngine.UI Assembly
 				typeof(Graphic).Assembly,
 			};
 

--- a/Serialization/ArgsList.cs
+++ b/Serialization/ArgsList.cs
@@ -9,6 +9,11 @@ namespace DUCK.Serialization
 	[Serializable]
 	public partial class ArgsList : ISerializationCallbackReceiver
 	{
+		public static bool IsSupportedType(Type type)
+		{
+			return supportedTypesArray.Contains(type) || type.IsSubclassOf(typeof(Component));
+		}
+
 		private static readonly Dictionary<string, SupportedType> supportedTypes;
 		private static readonly Type[] supportedTypesArray;
 		private static readonly Dictionary<string, Type> componentTypes;
@@ -86,7 +91,7 @@ namespace DUCK.Serialization
 
 			foreach (var argType in types)
 			{
-				if (!ValidateArgType(argType))
+				if (!IsSupportedType(argType))
 				{
 					throw new ArgumentException("Cannot handle arguments of type: " + argType.Name);
 				}
@@ -193,11 +198,6 @@ namespace DUCK.Serialization
 		private bool ValidateArgTypeForIndex(Type type, int index)
 		{
 			return argTypes.Count > index && argTypes[index] == type;
-		}
-
-		private bool ValidateArgType(Type type)
-		{
-			return supportedTypesArray.Contains(type) || type.IsSubclassOf(typeof(Component));
 		}
 	}
 }

--- a/Serialization/Editor/ArgsListTests.cs
+++ b/Serialization/Editor/ArgsListTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace DUCK.Serialization.Editor
 {
@@ -411,6 +412,32 @@ namespace DUCK.Serialization.Editor
 		}
 
 		[Test]
+		public void ExpectPolymorphicComponentSerializationToBeSupported()
+		{
+			var argsList = new ArgsList();
+
+			argsList.SetTypes(new List<Type>
+			{
+				typeof(Renderer),
+				typeof(Graphic),
+			});
+
+			// Add some data, serialize and deserialize
+			var gameObjectA = new GameObject();
+			var spriteRenderer = gameObjectA.AddComponent<SpriteRenderer>();
+			var image = gameObjectA.AddComponent<Image>();
+
+			argsList.Set(0, spriteRenderer);
+			argsList.Set(1, image);
+
+			var json = JsonUtility.ToJson(argsList);
+			var resultArgsList = JsonUtility.FromJson<ArgsList>(json);
+
+			Assert.AreEqual(spriteRenderer, resultArgsList[0]);
+			Assert.AreEqual(image, resultArgsList[1]);
+		}
+
+		[Test]
 		public void ExpectSerializationOfMultipleTypesToBeSupported()
 		{
 			var argsList = new ArgsList();
@@ -510,7 +537,7 @@ namespace DUCK.Serialization.Editor
 			argsList.Set(6, spriteRenderer);
 
 			var allArgs = argsList.AllArgs;
-			
+
 			// Now test the value is what it should be
 			Assert.AreEqual(argsList.Get<string>(0), allArgs[0]);
 			Assert.AreEqual(argsList.Get<int>(1), allArgs[1]);

--- a/Tween/Easings/EasingFunctionStore.cs
+++ b/Tween/Easings/EasingFunctionStore.cs
@@ -42,7 +42,8 @@ namespace DUCK.Tween.Easings
 				{"Quint.InOut", Ease.Quint.InOut},
 				{"Sine.In", Ease.Sine.In},
 				{"Sine.Out", Ease.Sine.Out},
-				{"Sine.InOut", Ease.Sine.InOut}
+				{"Sine.InOut", Ease.Sine.InOut},
+				{"Parabola", Ease.Parabola}
 			};
 		}
 	}

--- a/Tween/Easings/EasingFunctionStore.cs
+++ b/Tween/Easings/EasingFunctionStore.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace DUCK.Tween.Easings
+{
+	public class EasingFunctionStore
+	{
+		public static Dictionary<string, Func<float, float>> EasingFunctions { get; set; }
+		static EasingFunctionStore()
+		{
+			// Reflection could get all these but the invoke would be a lot slower at runtime
+			// Instead we just grab direct function references
+			EasingFunctions = new Dictionary<string, Func<float, float>>
+			{
+				{"Linear", Ease.Linear.None},
+				{"Back.In", Ease.Back.In},
+				{"Back.Out", Ease.Back.Out},
+				{"Back.InOut", Ease.Back.InOut},
+				{"Bounce.In", Ease.Bounce.In},
+				{"Bounce.Out", Ease.Bounce.Out},
+				{"Bounce.InOut", Ease.Bounce.InOut},
+				{"Circ.In", Ease.Circ.In},
+				{"Circ.Out", Ease.Circ.Out},
+				{"Circ.InOut", Ease.Circ.InOut},
+				{"Cubic.In", Ease.Cubic.In},
+				{"Cubic.Out", Ease.Cubic.Out},
+				{"Cubic.InOut", Ease.Cubic.InOut},
+				{"Elastic.In", Ease.Elastic.In},
+				{"Elastic.Out", Ease.Elastic.Out},
+				{"Elastic.InOut", Ease.Elastic.InOut},
+				{"Expo.In", Ease.Expo.In},
+				{"Expo.Out", Ease.Expo.Out},
+				{"Expo.InOut", Ease.Expo.InOut},
+				{"Quad.In", Ease.Quad.In},
+				{"Quad.Out", Ease.Quad.Out},
+				{"Quad.InOut", Ease.Quad.InOut},
+				{"Quart.In", Ease.Quart.In},
+				{"Quart.Out", Ease.Quart.Out},
+				{"Quart.InOut", Ease.Quart.InOut},
+				{"Quint.In", Ease.Quint.In},
+				{"Quint.Out", Ease.Quint.Out},
+				{"Quint.InOut", Ease.Quint.InOut},
+				{"Sine.In", Ease.Sine.In},
+				{"Sine.Out", Ease.Sine.Out},
+				{"Sine.InOut", Ease.Sine.InOut}
+			};
+		}
+	}
+}

--- a/Tween/Easings/EasingFunctionStore.cs
+++ b/Tween/Easings/EasingFunctionStore.cs
@@ -5,7 +5,7 @@ namespace DUCK.Tween.Easings
 {
 	public class EasingFunctionStore
 	{
-		public static Dictionary<string, Func<float, float>> EasingFunctions { get; set; }
+		public static Dictionary<string, Func<float, float>> EasingFunctions { get; private set; }
 		static EasingFunctionStore()
 		{
 			// Reflection could get all these but the invoke would be a lot slower at runtime

--- a/Tween/Easings/EasingFunctionStore.cs.meta
+++ b/Tween/Easings/EasingFunctionStore.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d50169b8d2a344e693ed2c791df97bbd
+timeCreated: 1510131075

--- a/Tween/Easings/Parabola.cs
+++ b/Tween/Easings/Parabola.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+
+namespace DUCK.Tween.Easings
+{
+	public static partial class Ease
+	{
+		public static float Parabola(float x) 
+		{
+			return 1f - Mathf.Pow((2f * x) - 1f, 2);
+		}
+	}
+}

--- a/Tween/Easings/Parabola.cs.meta
+++ b/Tween/Easings/Parabola.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c73ad38fb5434e08a221983e7ecc78f1
+timeCreated: 1511976184

--- a/Tween/Extensions/TransformAnimationExtensionsMove.cs
+++ b/Tween/Extensions/TransformAnimationExtensionsMove.cs
@@ -20,6 +20,28 @@ namespace DUCK.Tween.Extensions
 		}
 
 		/// <summary>
+		/// Creates a new MoveAnimation using 2 transforms
+		/// </summary>
+		/// <param name="transform">The transform that will be used in the MoveAnimation</param>
+		/// <param name="from">The transform to use for the start position of the MoveAnimation</param>
+		/// <param name="to">The transform to use for the end position of the MoveAnimation</param>
+		/// <param name="duration">The duration of the animation in seconds, defaults to 1f</param>
+		/// <param name="easingFunction">The easing function that will be used to interpolate with</param>
+		/// <returns>The newly created move Animation</returns>
+		public static DelegateAnimation<MoveAnimation> MoveBetween(this Transform transform, Transform from, Transform to, float duration = 1f, Func<float, float> easingFunction = null)
+		{
+			var animation = new DelegateAnimation<MoveAnimation>(() =>
+				new MoveAnimation(
+					transform.gameObject,
+					from.position,
+					to.position,
+					duration,
+					easingFunction,
+					false));
+			return animation;
+		}
+
+		/// <summary>
 		/// Creates a new MoveAnimation that uses local position using this transform
 		/// </summary>
 		/// <param name="transform">The transform that will be used in the MoveAnimation</param>

--- a/Tween/Serialization.meta
+++ b/Tween/Serialization.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c3ca90c9555d4d5fad6c0c9bc5f49813
+timeCreated: 1511967546

--- a/Tween/Serialization/Editor.meta
+++ b/Tween/Serialization/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5e0a660ccf14b188d7e3af60b9304a6
+folderAsset: yes
+timeCreated: 1511967817
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tween/Serialization/Editor/CreateTweenConfigScriptableObject.cs
+++ b/Tween/Serialization/Editor/CreateTweenConfigScriptableObject.cs
@@ -1,0 +1,14 @@
+﻿using DUCK.Editor;
+using UnityEditor;
+
+namespace DUCK.Tween.Serialization.Editor
+{
+	public class CreateTweenConfigScriptableObject
+	{
+		[MenuItem("DUCK/Tween/Create Tween Config")]
+		public static void CreateTweenConfig()
+		{
+			ScriptableObjectUtility.CreateAsset<TweenConfigScriptableObject>();
+		}
+	}
+}

--- a/Tween/Serialization/Editor/CreateTweenConfigScriptableObject.cs.meta
+++ b/Tween/Serialization/Editor/CreateTweenConfigScriptableObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a44634315a484874a0f4d75bb04429bb
+timeCreated: 1511857897

--- a/Tween/Serialization/Editor/TweenBuilderEditor.cs
+++ b/Tween/Serialization/Editor/TweenBuilderEditor.cs
@@ -16,6 +16,13 @@ namespace DUCK.Tween.Serialization.Editor
 		{
 			tweenBuilder.PlayOnStart = EditorGUILayout.Toggle("Play on Start", tweenBuilder.PlayOnStart);
 
+			tweenBuilder.Repeat = EditorGUILayout.Toggle("Repeat?", tweenBuilder.Repeat);
+
+			if (tweenBuilder.Repeat)
+			{
+				tweenBuilder.RepeatCount = EditorGUILayout.IntField("Repeat Count", tweenBuilder.RepeatCount);
+			}
+
 			tweenBuilder.UseReferencedConfig = EditorGUILayout.Toggle("Use referenced Config", tweenBuilder.UseReferencedConfig);
 
 			if (tweenBuilder.UseReferencedConfig)

--- a/Tween/Serialization/Editor/TweenBuilderEditor.cs
+++ b/Tween/Serialization/Editor/TweenBuilderEditor.cs
@@ -1,0 +1,35 @@
+﻿using UnityEditor;
+
+namespace DUCK.Tween.Serialization.Editor
+{
+	[CustomEditor(typeof(TweenBuilder))]
+	public class TweenBuilderEditor : UnityEditor.Editor
+	{
+		private TweenBuilder tweenBuilder;
+
+		public void OnEnable()
+		{
+			tweenBuilder = target as TweenBuilder;
+		}
+
+		public override void OnInspectorGUI()
+		{
+			tweenBuilder.PlayOnStart = EditorGUILayout.Toggle("Play on Start", tweenBuilder.PlayOnStart);
+
+			tweenBuilder.UseReferencedConfig = EditorGUILayout.Toggle("Use referenced Config", tweenBuilder.UseReferencedConfig);
+
+			if (tweenBuilder.UseReferencedConfig)
+			{
+				tweenBuilder.TweenConfigScriptableObject = (TweenConfigScriptableObject)
+					EditorGUILayout.ObjectField("Config", tweenBuilder.TweenConfigScriptableObject,
+						typeof(TweenConfigScriptableObject), false);
+			}
+			else
+			{
+				TweenConfigEditor.Draw(tweenBuilder.TweenConfig);
+			}
+		}
+
+		// TODO: provide support for handles for positions
+	}
+}

--- a/Tween/Serialization/Editor/TweenBuilderEditor.cs.meta
+++ b/Tween/Serialization/Editor/TweenBuilderEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1f53c950d0b94009a031861da27f0a7d
+timeCreated: 1509617769

--- a/Tween/Serialization/Editor/TweenConfigEditor.cs
+++ b/Tween/Serialization/Editor/TweenConfigEditor.cs
@@ -6,6 +6,7 @@ using DUCK.Serialization.Editor;
 using DUCK.Tween.Easings;
 using DUCK.Utils.Editor.EditorGUIHelpers;
 using UnityEditor;
+using UnityEngine;
 
 namespace DUCK.Tween.Serialization.Editor
 {
@@ -48,6 +49,26 @@ namespace DUCK.Tween.Serialization.Editor
 			}
 
 			ArgsListEditor.Draw(args, creatorFunction.ArgNames, customDrawFuncs);
+
+			ReportWarningForAnyNullObjectReferences(args);
+		}
+
+		private static void ReportWarningForAnyNullObjectReferences(ArgsList args)
+		{
+			for (int i = 0; i < args.AllArgs.Count; i++)
+			{
+				var type = args.ArgTypes[i];
+				if (type == typeof(GameObject) || type.IsSubclassOf(typeof(Component)))
+				{
+					if (args.AllArgs[i] == null)
+					{
+						var message = "TweenConfig contains one or more GameObject or Component references that are not set."
+							 + "\r\nWhen attempting to build the tween, the TweenBuilder will use the current GameObject or attempt to find the correct components on the current GameObject";
+						EditorGUILayout.HelpBox(message, MessageType.Info);
+						return;
+					}
+				}
+			}
 		}
 
 		private static object DrawEasingSelector(string label, object value)

--- a/Tween/Serialization/Editor/TweenConfigEditor.cs
+++ b/Tween/Serialization/Editor/TweenConfigEditor.cs
@@ -5,6 +5,7 @@ using DUCK.Serialization;
 using DUCK.Serialization.Editor;
 using DUCK.Tween.Easings;
 using DUCK.Utils.Editor.EditorGUIHelpers;
+using UnityEditor;
 
 namespace DUCK.Tween.Serialization.Editor
 {
@@ -13,20 +14,28 @@ namespace DUCK.Tween.Serialization.Editor
 		public static void Draw(TweenConfig tweenConfig)
 		{
 			ArgsList args = tweenConfig.Args;
-			
+
 			tweenConfig.CreatorFunctionKey = EditorGUILayoutHelpers.OptionSelectorField(
 				"Creator Function",
 				tweenConfig.CreatorFunctionKey,
 				TweenCreatorFunctionStore.Keys);
 
-			if (string.IsNullOrEmpty(tweenConfig.CreatorFunctionKey))
+			var creatorFunctionKey = tweenConfig.CreatorFunctionKey;
+
+			if (string.IsNullOrEmpty(creatorFunctionKey))
 			{
-				// TODO: draw warning
+				EditorGUILayout.HelpBox("No creator function selected, nothing will be executed!", MessageType.Info);
 				return;
 			}
 
-			var creatorFunction = TweenCreatorFunctionStore.Get(tweenConfig.CreatorFunctionKey);
-			// TODO: catch if function cannot be found
+			if (!TweenCreatorFunctionStore.Exists(creatorFunctionKey))
+			{
+				var message = "Creator function with the key " + creatorFunctionKey + " could not be found!";
+				EditorGUILayout.HelpBox(message, MessageType.Error);
+				return;
+			}
+
+			var creatorFunction = TweenCreatorFunctionStore.Get(creatorFunctionKey);
 
 			if (tweenConfig.Args == null) tweenConfig.Args = args = new ArgsList();
 			args.SetTypes(creatorFunction.SerializedArgTypes);

--- a/Tween/Serialization/Editor/TweenConfigEditor.cs
+++ b/Tween/Serialization/Editor/TweenConfigEditor.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DUCK.Serialization;
+using DUCK.Serialization.Editor;
+using DUCK.Tween.Easings;
+using DUCK.Utils.Editor.EditorGUIHelpers;
+
+namespace DUCK.Tween.Serialization.Editor
+{
+	public class TweenConfigEditor
+	{
+		public static void Draw(TweenConfig tweenConfig)
+		{
+			ArgsList args = tweenConfig.Args;
+			
+			tweenConfig.CreatorFunctionKey = EditorGUILayoutHelpers.OptionSelectorField(
+				"Creator Function",
+				tweenConfig.CreatorFunctionKey,
+				TweenCreatorFunctionStore.Keys);
+
+			if (string.IsNullOrEmpty(tweenConfig.CreatorFunctionKey))
+			{
+				// TODO: draw warning
+				return;
+			}
+
+			var creatorFunction = TweenCreatorFunctionStore.Get(tweenConfig.CreatorFunctionKey);
+			// TODO: catch if function cannot be found
+
+			if (tweenConfig.Args == null) tweenConfig.Args = args = new ArgsList();
+			args.SetTypes(creatorFunction.SerializedArgTypes);
+
+			var indexOfEasingArg = creatorFunction.RealArgTypes.IndexOf(typeof(Func<float, float>));
+			var customDrawFuncs = new Dictionary<int, ArgsListEditor.CustomArgDrawFunc>();
+			if (indexOfEasingArg >= 0)
+			{
+				customDrawFuncs[indexOfEasingArg] = DrawEasingSelector;
+			}
+
+			ArgsListEditor.Draw(args, creatorFunction.ArgNames, customDrawFuncs);
+		}
+
+		private static object DrawEasingSelector(string label, object value)
+		{
+			var options = EasingFunctionStore.EasingFunctions.Keys.ToArray();
+			return EditorGUILayoutHelpers.OptionSelectorField(label, (string) value, options);
+		}
+	}
+}

--- a/Tween/Serialization/Editor/TweenConfigEditor.cs.meta
+++ b/Tween/Serialization/Editor/TweenConfigEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e940264c8e2b426b85623604f7505c6f
+timeCreated: 1511856473

--- a/Tween/Serialization/Editor/TweenConfigScriptableObjectEditor.cs
+++ b/Tween/Serialization/Editor/TweenConfigScriptableObjectEditor.cs
@@ -1,0 +1,20 @@
+﻿using UnityEditor;
+
+namespace DUCK.Tween.Serialization.Editor
+{
+	[CustomEditor(typeof(TweenConfigScriptableObject))]
+	public class TweenConfigScriptableObjectEditor : UnityEditor.Editor
+	{
+		private TweenConfigScriptableObject tweenConfigScriptableObject;
+
+		public void OnEnable()
+		{
+			tweenConfigScriptableObject = target as TweenConfigScriptableObject;
+		}
+
+		public override void OnInspectorGUI()
+		{
+			TweenConfigEditor.Draw(tweenConfigScriptableObject.Config);
+		}
+	}
+}

--- a/Tween/Serialization/Editor/TweenConfigScriptableObjectEditor.cs.meta
+++ b/Tween/Serialization/Editor/TweenConfigScriptableObjectEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1ce3288edea54d2987a71283747ddf9e
+timeCreated: 1511857799

--- a/Tween/Serialization/TweenBuilder.cs
+++ b/Tween/Serialization/TweenBuilder.cs
@@ -36,8 +36,8 @@ namespace DUCK.Tween.Serialization
 		public void Play()
 		{
 			var config = useReferencedConfig ? tweenConfigScriptableObject.Config : TweenConfig;
-			var animation = BuildTween(config, gameObject);
-			animation.Play();
+			var tween = BuildTween(config, gameObject);
+			tween.Play();
 		}
 
 #if UNITY_EDITOR

--- a/Tween/Serialization/TweenBuilder.cs
+++ b/Tween/Serialization/TweenBuilder.cs
@@ -12,6 +12,12 @@ namespace DUCK.Tween.Serialization
 		private bool playOnStart;
 
 		[SerializeField]
+		private bool repeat;
+
+		[SerializeField]
+		private int repeatCount;
+
+		[SerializeField]
 		private bool useReferencedConfig;
 
 		[SerializeField]
@@ -39,7 +45,14 @@ namespace DUCK.Tween.Serialization
 			var tween = BuildTween(config, gameObject);
 			if (tween != null)
 			{
-				tween.Play();
+				if (Repeat)
+				{
+					tween.Play(RepeatCount);
+				}
+				else
+				{
+					tween.Play();
+				}
 			}
 		}
 
@@ -48,6 +61,18 @@ namespace DUCK.Tween.Serialization
 		{
 			get { return playOnStart; }
 			set { playOnStart = value; }
+		}
+
+		public bool Repeat
+		{
+			get { return repeat; }
+			set { repeat = value; }
+		}
+
+		public int RepeatCount
+		{
+			get { return repeatCount; }
+			set { repeatCount = value; }
 		}
 
 		public bool UseReferencedConfig

--- a/Tween/Serialization/TweenBuilder.cs
+++ b/Tween/Serialization/TweenBuilder.cs
@@ -37,7 +37,10 @@ namespace DUCK.Tween.Serialization
 		{
 			var config = useReferencedConfig ? tweenConfigScriptableObject.Config : TweenConfig;
 			var tween = BuildTween(config, gameObject);
-			tween.Play();
+			if (tween != null)
+			{
+				tween.Play();
+			}
 		}
 
 #if UNITY_EDITOR
@@ -62,7 +65,13 @@ namespace DUCK.Tween.Serialization
 
 		public static AbstractAnimation BuildTween(TweenConfig config, GameObject defaultTarget)
 		{
-			var creatorFunction = TweenCreatorFunctionStore.Get(config.CreatorFunctionKey);
+			var creatorFunctionKey = config.CreatorFunctionKey;
+			if (!TweenCreatorFunctionStore.Exists(creatorFunctionKey))
+			{
+				Debug.LogError("Cannot build tween: Creator function `" + creatorFunctionKey + "` could not be found!");
+				return null;
+			}
+			var creatorFunction = TweenCreatorFunctionStore.Get(creatorFunctionKey);
 
 			// For any null args that are game objects or components, let's try to use this object
 			var args = config.Args.AllArgs.ToArray();

--- a/Tween/Serialization/TweenBuilder.cs
+++ b/Tween/Serialization/TweenBuilder.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using UnityEngine;
+
+namespace DUCK.Tween.Serialization
+{
+	public class TweenBuilder : MonoBehaviour
+	{
+		[SerializeField]
+		private bool playOnStart;
+
+		[SerializeField]
+		private bool useReferencedConfig;
+
+		[SerializeField]
+		private TweenConfigScriptableObject tweenConfigScriptableObject;
+
+		[SerializeField]
+		private TweenConfig tweenConfig = new TweenConfig();
+		public TweenConfig TweenConfig
+		{
+			get { return tweenConfig; }
+			set { tweenConfig = value; }
+		}
+
+		private void Start()
+		{
+			if (playOnStart)
+			{
+				Play();
+			}
+		}
+
+		public void Play()
+		{
+			var config = useReferencedConfig ? tweenConfigScriptableObject.Config : TweenConfig;
+			var creatorFunction = TweenCreatorFunctionStore.Get(config.CreatorFunctionKey);
+			
+			// TODO: catch null targets and try to use this object
+
+			var animation = creatorFunction.CreationMethod.Invoke(config.Args.AllArgs.ToArray());
+			animation.Play();
+		}
+
+#if UNITY_EDITOR
+		public bool PlayOnStart
+		{
+			get { return playOnStart; }
+			set { playOnStart = value; }
+		}
+
+		public bool UseReferencedConfig
+		{
+			get { return useReferencedConfig; }
+			set { useReferencedConfig = value; }
+		}
+
+		public TweenConfigScriptableObject TweenConfigScriptableObject
+		{
+			get { return tweenConfigScriptableObject; }
+			set { tweenConfigScriptableObject = value; }
+		}
+#endif
+	}
+}

--- a/Tween/Serialization/TweenBuilder.cs.meta
+++ b/Tween/Serialization/TweenBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7884f2474cc44f909c688b548c32f064
+timeCreated: 1509617754

--- a/Tween/Serialization/TweenConfig.cs
+++ b/Tween/Serialization/TweenConfig.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using DUCK.Serialization;
+using UnityEngine;
+
+namespace DUCK.Tween.Serialization
+{
+	[Serializable]
+	public class TweenConfig
+	{
+		[SerializeField]
+		private string creatorFunctionKey;
+		
+		[SerializeField]
+		private ArgsList args = new ArgsList();
+
+		// These properties get exposed but only for UNITY_EDITOR for custom editor access
+		public string CreatorFunctionKey
+		{
+			get { return creatorFunctionKey; }
+#if !UNITY_EDITOR
+			private
+#endif
+			set { creatorFunctionKey = value; }
+		}
+		public ArgsList Args
+		{
+			get { return args; }
+#if !UNITY_EDITOR
+			private
+#endif
+			set { args = value; }
+		}
+	}
+}

--- a/Tween/Serialization/TweenConfig.cs.meta
+++ b/Tween/Serialization/TweenConfig.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d2cb1ef0000d4994bd713e431d158f07
+timeCreated: 1511856441

--- a/Tween/Serialization/TweenConfigScriptableObject.cs
+++ b/Tween/Serialization/TweenConfigScriptableObject.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+namespace DUCK.Tween.Serialization
+{
+	[CreateAssetMenu(menuName = "Tween Config (Fancy™)", order = 230)]
+	public class TweenConfigScriptableObject : ScriptableObject
+	{
+		[SerializeField]
+		private TweenConfig config = new TweenConfig();
+		public TweenConfig Config
+		{
+			get { return config; }
+			set { config = value; }
+		}
+	}
+}

--- a/Tween/Serialization/TweenConfigScriptableObject.cs.meta
+++ b/Tween/Serialization/TweenConfigScriptableObject.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e0e4aa06dca54c17a64838e4242cf399
+timeCreated: 1511857811

--- a/Tween/Serialization/TweenCreatorFunctionStore.cs
+++ b/Tween/Serialization/TweenCreatorFunctionStore.cs
@@ -31,11 +31,11 @@ namespace DUCK.Tween.Serialization
 				var parameters = method.GetParameters();
 				return parameters.All(p =>
 				{
-					// All types must supported by Args list or be a Func<float,float> (easing function) 
+					// All types must supported by Args list or be a Func<float,float> (easing function)
 					return ArgsList.IsSupportedType(p.ParameterType) || p.ParameterType == typeof(Func<float, float>);
 				});
 			};
-			
+
 			// Grab all constructors of listed types and use these.
 			new[]
 			{
@@ -76,6 +76,11 @@ namespace DUCK.Tween.Serialization
 						tweenCreatorFunctionInfos.Add(key, func);
 					});
 			});
+		}
+
+		public static bool Exists(string key)
+		{
+			return tweenCreatorFunctionInfos.ContainsKey(key);
 		}
 
 		public static TweenCreatorFunctionInfo Get(string key)

--- a/Tween/Serialization/TweenCreatorFunctionStore.cs
+++ b/Tween/Serialization/TweenCreatorFunctionStore.cs
@@ -78,6 +78,11 @@ namespace DUCK.Tween.Serialization
 			});
 		}
 
+		public static void Add(string key, TweenCreatorFunctionInfo functionInfo)
+		{
+			tweenCreatorFunctionInfos.Add(key, functionInfo);
+		}
+
 		public static bool Exists(string key)
 		{
 			return tweenCreatorFunctionInfos.ContainsKey(key);

--- a/Tween/Serialization/TweenCreatorFunctionStore.cs
+++ b/Tween/Serialization/TweenCreatorFunctionStore.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DUCK.Tween.Easings;
+using DUCK.Tween.Extensions;
+using DUCK.Utils;
+
+namespace DUCK.Tween.Serialization
+{
+	/// <summary>
+	/// Holds info about functions that can be used to create tweens.
+	/// This is used in conjunction with the TweenBuilder to provide editor gui to create tweens at editor time.
+	/// </summary>
+	public static class TweenCreatorFunctionStore
+	{
+		public static string[] Keys
+		{
+			get { return tweenCreatorFunctionInfos.Keys.ToArray(); }
+		}
+
+		private static readonly Dictionary<string, TweenCreatorFunctionInfo> tweenCreatorFunctionInfos;
+
+		static TweenCreatorFunctionStore()
+		{
+			tweenCreatorFunctionInfos = new Dictionary<string, TweenCreatorFunctionInfo>();
+
+			// Grab all constructors of listed types and use these.
+			new[]
+			{
+				typeof(MoveAnimation),
+				typeof(RotateAnimation),
+				typeof(ScaleAnimation),
+				typeof(RendererColorFadeAnimation),
+				typeof(UIColorFadeAnimation),
+				typeof(RendererFadeAnimation),
+				typeof(UIFadeAnimation),
+			}.ForEach(t =>
+			{
+				t.GetConstructors().ForEach(c =>
+				{
+					var key = StringifyConstructor(c);
+					var func = TweenCreatorFunctionInfo.FromMethod(c);
+					tweenCreatorFunctionInfos.Add(key, func);
+				});
+			});
+
+			// Grab all extension methods of the following types
+			new[]
+			{
+				typeof(TransformAnimationExtensions),
+				typeof(RectTransformAnimationExtensions),
+				typeof(RendererAnimationExtensions),
+				typeof(UIComponentAnimationExtensions),
+			}.ForEach(t =>
+			{
+				t.GetMethods(BindingFlags.Public | BindingFlags.Static)
+					.ForEach(m =>
+					{
+						var key = StringifyExtMethod(m);
+						var func = TweenCreatorFunctionInfo.FromMethod(m);
+						tweenCreatorFunctionInfos.Add(key, func);
+					});
+			});
+		}
+
+		public static TweenCreatorFunctionInfo Get(string key)
+		{
+			return tweenCreatorFunctionInfos.ContainsKey(key) ? tweenCreatorFunctionInfos[key] : null;
+		}
+
+		private static string StringifyConstructor(ConstructorInfo ctor)
+		{
+			var name = ctor.DeclaringType.Name;
+			return ".ctor:" + name + "(" + StringifyMethodParams(ctor) + ")";
+		}
+
+		private static string StringifyExtMethod(MethodInfo method)
+		{
+			var name = method.Name;
+			return ".ext:" + name + "(" + StringifyMethodParams(method) + ")";
+		}
+
+		private static string StringifyMethodParams(MethodBase method)
+		{
+			var parameters = method.GetParameters().Select(p => p.ParameterType.Name).ToArray();
+			var paramsString = "";
+			for (var i = 0; i < parameters.Length; i++)
+			{
+				paramsString += parameters[i] + (i == parameters.Length - 1 ? "" : ",");
+			}
+			return paramsString;
+		}
+	}
+
+	public class TweenCreatorFunctionInfo
+	{
+		public List<Type> RealArgTypes { get; private set; }
+		public List<Type> SerializedArgTypes { get; private set; }
+		public List<string> ArgNames { get; private set; }
+		public Func<object[], AbstractAnimation> CreationMethod { get; private set; }
+
+		public static TweenCreatorFunctionInfo FromMethod(MethodBase method)
+		{
+			var info = new TweenCreatorFunctionInfo();
+			var parameterInfos = method.GetParameters();
+			info.ArgNames = parameterInfos.Select(a => a.Name).ToList();
+			info.RealArgTypes = parameterInfos.Select(a => a.ParameterType).ToList();
+			info.SerializedArgTypes = parameterInfos.Select(a => a.ParameterType).Select(MapArgTypes).ToList();
+			info.CreationMethod = args => (AbstractAnimation) method.Invoke(null, MapArgs(method, args));
+			return info;
+		}
+
+		private static object[] MapArgs(MethodBase func, object[] args)
+		{
+			var paramaterInfos = func.GetParameters();
+			for (var i = 0; i < paramaterInfos.Length; i++)
+			{
+				// TODO: abstract this out so we can plug in any arg converters
+				if (paramaterInfos[i].ParameterType == typeof(Func<float, float>))
+				{
+					var easingFunctionKey = (string) args[i];
+					if (EasingFunctionStore.EasingFunctions.ContainsKey(easingFunctionKey))
+					{
+						args[i] = EasingFunctionStore.EasingFunctions[easingFunctionKey];
+					}
+					else
+					{
+						args[i] = (Func<float, float>) Ease.Linear.None;
+					}
+				}
+			}
+
+			return args;
+		}
+
+		private static Type MapArgTypes(Type type)
+		{
+			if (type == typeof(Func<float, float>))
+			{
+				return typeof(string);
+			}
+			return type;
+		}
+	}
+}

--- a/Tween/Serialization/TweenCreatorFunctionStore.cs.meta
+++ b/Tween/Serialization/TweenCreatorFunctionStore.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d9d2687dce1348868727890e56c92e91
+timeCreated: 1509715785


### PR DESCRIPTION
# Setup your tweens in the editor!

## No Code Required
You can now set up tweens in the editor, using the "TweenBuilder" script, it will allow you to choose which type of tween to create, and then select all the parameters you want, and it will be saved in the scene/prefab!
![tween-builder](https://user-images.githubusercontent.com/5612566/33474166-4d5f6e18-d671-11e7-8181-053dcbee5820.png)

## ScriptableObject support
Just tick "Use referenced Config" and you can configure a tween in a scriptable object. and apply that tween to several objects. (The target cannot be serialized in a scriptable object, so it will just use the TweenBuilder object as a target or look for  the correct component on there).

![scriptable-object](https://user-images.githubusercontent.com/5612566/33474318-0a40061e-d672-11e7-96f9-5aa637b31ef0.png)

## Supports Most Tweens!
it supports most of the built in tween types, and can be made most any of the constructors and extension functions you already use*
![tween-creator-functions](https://user-images.githubusercontent.com/5612566/33474216-88d0d48c-d671-11e7-80b5-838ad567b329.png)
\* We filter out functions that have unsupported args; those not supported by ArgsList, such as quaternion. However we also make special cases like `Func<float,float>`. Although we cannot serialize this, we know that this type is the easing function, therefore we actually just store it as a string, and we can lookup the key later


## Extendable
The list above comes from a public static dictionary, so you will be able to register your own creator functions by using `TweenCreatorFunctionStore` (API example incoming)

## Easings
![easing-functions](https://user-images.githubusercontent.com/5612566/33474359-2caf15f0-d672-11e7-9497-33968eaf0b35.png)
We support all built in easings and again you can plug your own in using `EasingFunctionsStore.EasingFunctions.Add("key", MyEasingFunction)`


# Current State

## TODO

- Add more built in creator functions so we can move between 2 referenced transforms (won't work for scriptable objects)
- Add support for adding your own Tween Creation Functions
- Some improved error handling in a few places
- Draw warnings to inspector about null targets (and explain the behaviour in this instance)
- Add support for handles when specifying Vector 3 positions
- Looping support

## What can it not do?
Sequenced animations are not possible, I thought about how to implement it but it gets pretty complicated, at that point I'd say you want something really custom anyway, and may as well jsut write the code, This is intended for quickly adding basic effects like popping/fading etc... Complicated chains are probably better to be explicitly expressed as code.


