### PR TITLE
Added child object creation helpers

### DIFF
--- a/Utils/GameObjectExtensions.cs
+++ b/Utils/GameObjectExtensions.cs
@@ -24,7 +24,7 @@ namespace DUCK.Utils
 		/// rotation and scale as before.</param>
 		/// <typeparam name="TComponent">The component to add to the child game object</typeparam>
 		/// <returns>The newly created component</returns>
-		public static TComponent AddChildObjectWithComponent<TComponent>(this GameObject obj, bool worldPositionStays = true)
+		public static TComponent AddChildWithComponent<TComponent>(this GameObject obj, bool worldPositionStays = true)
 			where TComponent : Component
 		{
 			var component = new GameObject(typeof(TComponent).Name).AddComponent<TComponent>();
@@ -33,7 +33,7 @@ namespace DUCK.Utils
 		}
 
 		/// <summary>
-		/// Instantiates a prefab and adds it as a child of this game object
+		/// Instantiates a prefab from resources and adds it as a child of this game object
 		/// </summary>
 		/// <param name="obj">The target game object</param>
 		/// <param name="path">The path of the resource to load</param>
@@ -42,7 +42,7 @@ namespace DUCK.Utils
 		/// rotation and scale as before.</param>
 		/// <typeparam name="TComponent">The type of component expected on the prefab and that will be returned</typeparam>
 		/// <returns>The TComponent found on the prefab</returns>
-		public static TComponent AddInstantiatedChild<TComponent>(this GameObject obj, string path,
+		public static TComponent AddResourceChild<TComponent>(this GameObject obj, string path,
 			bool worldPositionStays = true)
 			where TComponent : Component
 		{

--- a/Utils/GameObjectExtensions.cs
+++ b/Utils/GameObjectExtensions.cs
@@ -14,5 +14,39 @@ namespace DUCK.Utils
 		{
 			return gameObject.transform.IsInViewOf(camera);
 		}
+
+		/// <summary>
+		/// Creates a new child object of this game object, that has the given component and the name of that component
+		/// </summary>
+		/// <param name="obj">The target game object</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The component to add to the child game object</typeparam>
+		/// <returns>The newly created component</returns>
+		public static TComponent AddChildObjectWithComponent<TComponent>(this GameObject obj, bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			var component = new GameObject(typeof(TComponent).Name).AddComponent<TComponent>();
+			component.transform.SetParent(obj.transform, worldPositionStays);
+			return component;
+		}
+
+		/// <summary>
+		/// Instantiates a prefab and adds it as a child of this game object
+		/// </summary>
+		/// <param name="obj">The target game object</param>
+		/// <param name="path">The path of the resource to load</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The type of component expected on the prefab and that will be returned</typeparam>
+		/// <returns>The TComponent found on the prefab</returns>
+		public static TComponent AddInstantiatedChild<TComponent>(this GameObject obj, string path,
+			bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			return Instantiator.InstantiateResource<TComponent>(path, obj.transform, worldPositionStays);
+		}
 	}
 }

--- a/Utils/TransformExtensions.cs
+++ b/Utils/TransformExtensions.cs
@@ -116,7 +116,7 @@ namespace DUCK.Utils
 		/// rotation and scale as before.</param>
 		/// <typeparam name="TComponent">The component to add to the child game object</typeparam>
 		/// <returns>The newly created component</returns>
-		public static TComponent AddChildObjectWithComponent<TComponent>(this Transform transform, bool worldPositionStays = true)
+		public static TComponent AddChildWithComponent<TComponent>(this Transform transform, bool worldPositionStays = true)
 			where TComponent : Component
 		{
 			var component = new GameObject(typeof(TComponent).Name).AddComponent<TComponent>();
@@ -125,7 +125,7 @@ namespace DUCK.Utils
 		}
 
 		/// <summary>
-		/// Instantiates a prefab and adds it as a child of this transform
+		/// Instantiates a prefab from resources and adds it as a child of this transform
 		/// </summary>
 		/// <param name="obj">The target transform</param>
 		/// <param name="path">The path of the resource to load</param>
@@ -134,7 +134,7 @@ namespace DUCK.Utils
 		/// rotation and scale as before.</param>
 		/// <typeparam name="TComponent">The type of component expected on the prefab and that will be returned</typeparam>
 		/// <returns>The TComponent found on the prefab</returns>
-		public static TComponent AddInstantiatedChild<TComponent>(this Transform transform, string path,
+		public static TComponent AddResourceChild<TComponent>(this Transform transform, string path,
 			bool worldPositionStays = true)
 			where TComponent : Component
 		{

--- a/Utils/TransformExtensions.cs
+++ b/Utils/TransformExtensions.cs
@@ -105,5 +105,40 @@ namespace DUCK.Utils
 			}
 			rectTransform.pivot = pivot;
 		}
+
+		/// <summary>
+		/// Creates a new child object of this transform, that has the given component and
+		/// the name of that component.
+		/// </summary>
+		/// <param name="transform">The target transform</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The component to add to the child game object</typeparam>
+		/// <returns>The newly created component</returns>
+		public static TComponent AddChildObjectWithComponent<TComponent>(this Transform transform, bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			var component = new GameObject(typeof(TComponent).Name).AddComponent<TComponent>();
+			component.transform.SetParent(transform, worldPositionStays);
+			return component;
+		}
+
+		/// <summary>
+		/// Instantiates a prefab and adds it as a child of this transform
+		/// </summary>
+		/// <param name="obj">The target transform</param>
+		/// <param name="path">The path of the resource to load</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The type of component expected on the prefab and that will be returned</typeparam>
+		/// <returns>The TComponent found on the prefab</returns>
+		public static TComponent AddInstantiatedChild<TComponent>(this Transform transform, string path,
+			bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			return Instantiator.InstantiateResource<TComponent>(path, transform, worldPositionStays);
+		}
 	}
 }


### PR DESCRIPTION
## What ? ##
Extension methods for `GameObject` and `Transform` to aid the creation of child objects.

## Why ? ##
These functions are essentially doing what `AbstractController` does when adding a child. It's a useful thing to want to do and `AbstractController` will sort it for you in most cases, however moving it to here allows you to use it outside the `AbstractController` ecosystem

## How

`AddChildObjectWithComponent<TComponent>` -> add a child to the game object with the component attached and name it as the component's name

`AddInstantiatedChild<TComponent>(pathToPrefab)` -> Instantiate a prefab as a child.

Both support `worldPositionStays`



