### PR TITLE
Implemented util for broadcasting events to objects

### DIFF
--- a/Utils/Broadcaster.cs
+++ b/Utils/Broadcaster.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using UnityEngine;
+
+namespace DUCK.Utils
+{
+	public static class Broadcaster
+	{
+		public static void BroadcastTo<T>(GameObject gameObject, Action<T> execute, bool broadcastToChildren = true)
+		{
+			if (broadcastToChildren)
+			{
+				var children = gameObject.GetComponentsInChildren<T>();
+				foreach (var child in children)
+				{
+					execute(child);
+				}
+			}
+			else
+			{
+				var components = gameObject.GetComponents<T>();
+				foreach (var component in components)
+				{
+					execute(component);
+				}
+			}
+		}
+	}
+}

--- a/Utils/Broadcaster.cs.meta
+++ b/Utils/Broadcaster.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 55087f0b6ac04b0bb61e373cc2e490c3
+timeCreated: 1515424173

--- a/Utils/Editor/Tests/BroadcasterTests.cs
+++ b/Utils/Editor/Tests/BroadcasterTests.cs
@@ -27,7 +27,7 @@ namespace DUCK.Utils.Editor.Tests
 			var obj = new GameObject();
 			var behaviour = obj.AddComponent<TestBehaviour>();
 
-			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent());
+			Broadcaster.BroadcastTo<IEventHandler>(obj, o => o.HandleTheEvent());
 
 			Assert.IsTrue(behaviour.WasCalled);
 
@@ -41,7 +41,7 @@ namespace DUCK.Utils.Editor.Tests
 			var behaviour = obj.AddComponent<TestBehaviour>();
 			var behaviour2 = obj.AddComponent<TestBehaviour>();
 
-			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent());
+			Broadcaster.BroadcastTo<IEventHandler>(obj, o => o.HandleTheEvent());
 
 			Assert.IsTrue(behaviour.WasCalled);
 			Assert.IsTrue(behaviour2.WasCalled);
@@ -57,7 +57,7 @@ namespace DUCK.Utils.Editor.Tests
 			child.transform.SetParent(obj.transform);
 			var behaviour = child.AddComponent<TestBehaviour>();
 
-			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent());
+			Broadcaster.BroadcastTo<IEventHandler>(obj, o => o.HandleTheEvent());
 
 			Assert.IsTrue(behaviour.WasCalled);
 
@@ -72,7 +72,7 @@ namespace DUCK.Utils.Editor.Tests
 			child.transform.SetParent(obj.transform);
 			var behaviour = child.AddComponent<TestBehaviour>();
 
-			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent(), false);
+			Broadcaster.BroadcastTo<IEventHandler>(obj, o => o.HandleTheEvent(), false);
 
 			Assert.IsFalse(behaviour.WasCalled);
 

--- a/Utils/Editor/Tests/BroadcasterTests.cs
+++ b/Utils/Editor/Tests/BroadcasterTests.cs
@@ -1,0 +1,82 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+
+namespace DUCK.Utils.Editor.Tests
+{
+	interface IEventHandler
+	{
+		void HandleTheEvent();
+	}
+
+	class TestBehaviour : MonoBehaviour, IEventHandler
+	{
+		public bool WasCalled { get; private set; }
+
+		public void HandleTheEvent()
+		{
+			WasCalled = true;
+		}
+	}
+
+	[TestFixture]
+	public class BroadcasterTests
+	{
+		[Test]
+		public void ExpectBroadcasterToExecuteFunctionOnTargetObject()
+		{
+			var obj = new GameObject();
+			var behaviour = obj.AddComponent<TestBehaviour>();
+
+			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent());
+
+			Assert.IsTrue(behaviour.WasCalled);
+
+			Object.DestroyImmediate(obj);
+		}
+
+		[Test]
+		public void ExpectBroadcasterToExecuteAllFunctionsOnTargetObject()
+		{
+			var obj = new GameObject();
+			var behaviour = obj.AddComponent<TestBehaviour>();
+			var behaviour2 = obj.AddComponent<TestBehaviour>();
+
+			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent());
+
+			Assert.IsTrue(behaviour.WasCalled);
+			Assert.IsTrue(behaviour2.WasCalled);
+
+			Object.DestroyImmediate(obj);
+		}
+
+		[Test]
+		public void ExpectBroadcasterToExecuteFunctionOnChildObject()
+		{
+			var obj = new GameObject();
+			var child = new GameObject();
+			child.transform.SetParent(obj.transform);
+			var behaviour = child.AddComponent<TestBehaviour>();
+
+			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent());
+
+			Assert.IsTrue(behaviour.WasCalled);
+
+			Object.DestroyImmediate(obj);
+		}
+
+		[Test]
+		public void ExpectBroadcasterNotToExecuteFunctionOnChildObjectIfParameterWasSet()
+		{
+			var obj = new GameObject();
+			var child = new GameObject();
+			child.transform.SetParent(obj.transform);
+			var behaviour = child.AddComponent<TestBehaviour>();
+
+			Broadcaster.BroadcastTo<IEventHandler>(obj, testBehaviour => testBehaviour.HandleTheEvent(), false);
+
+			Assert.IsFalse(behaviour.WasCalled);
+
+			Object.DestroyImmediate(obj);
+		}
+	}
+}

--- a/Utils/Editor/Tests/BroadcasterTests.cs
+++ b/Utils/Editor/Tests/BroadcasterTests.cs
@@ -3,24 +3,24 @@ using UnityEngine;
 
 namespace DUCK.Utils.Editor.Tests
 {
-	private interface IEventHandler
-	{
-		void HandleTheEvent();
-	}
-
-	private class TestBehaviour : MonoBehaviour, IEventHandler
-	{
-		public bool WasCalled { get; private set; }
-
-		public void HandleTheEvent()
-		{
-			WasCalled = true;
-		}
-	}
-
 	[TestFixture]
 	public class BroadcasterTests
 	{
+		private interface IEventHandler
+		{
+			void HandleTheEvent();
+		}
+
+		private class TestBehaviour : MonoBehaviour, IEventHandler
+		{
+			public bool WasCalled { get; private set; }
+
+			public void HandleTheEvent()
+			{
+				WasCalled = true;
+			}
+		}
+
 		[Test]
 		public void ExpectBroadcasterToExecuteFunctionOnTargetObject()
 		{

--- a/Utils/Editor/Tests/BroadcasterTests.cs
+++ b/Utils/Editor/Tests/BroadcasterTests.cs
@@ -3,12 +3,12 @@ using UnityEngine;
 
 namespace DUCK.Utils.Editor.Tests
 {
-	interface IEventHandler
+	private interface IEventHandler
 	{
 		void HandleTheEvent();
 	}
 
-	class TestBehaviour : MonoBehaviour, IEventHandler
+	private class TestBehaviour : MonoBehaviour, IEventHandler
 	{
 		public bool WasCalled { get; private set; }
 

--- a/Utils/Editor/Tests/BroadcasterTests.cs.meta
+++ b/Utils/Editor/Tests/BroadcasterTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c823e6d7523844e2862a999474236ef3
+timeCreated: 1515424229


### PR DESCRIPTION
This is to support one of my favourite patterns of late. Broadcasting events to objects by targetting interfaces specifically designed to catch your events. Very similar to unity's `IPointerEventHandler` etc...

## Usage

`Broadcaster.BroadcastTo<IEventHandler>(targetObject, o => o.HandleTheEvent());`

It will execute your callback on all the objects found of the given type. By default it also searches for the component in the children. This can be disabled using the optional 3rd parameter (defaults to true)

  