### PR TITLE
Debug Button Destroy Fix

### DIFF
--- a/DebugMenu/DebugMenu.cs
+++ b/DebugMenu/DebugMenu.cs
@@ -214,7 +214,7 @@ namespace DUCK.DebugMenu
 
 			if (buttons.ContainsKey(text))
 			{
-				Destroy(buttons[text]);
+				Destroy(buttons[text].gameObject);
 				buttons.Remove(text);
 			}
 		}


### PR DESCRIPTION
Fixed issue of deleting the Button component rather than the GameObject, leaving a dud button