### PR TITLE
Project Editor Prefs

### DIFF
--- a/Editor/ProjectEditorPrefsWindow.cs
+++ b/Editor/ProjectEditorPrefsWindow.cs
@@ -21,9 +21,10 @@ namespace DUCK.Editor
 		private void OnGUI()
 		{
 			var types = ProjectEditorPrefs.StoredPrefs;
-			foreach (var key in types.Keys.ToList())
+			foreach (var pair in types.ToList())
 			{
-				var type = types[key];
+				var key = pair.Key;
+				var type = pair.Value;
 				var value = ProjectEditorPrefs.Get(key);
 
 				EditorGUI.BeginChangeCheck();

--- a/Editor/ProjectEditorPrefsWindow.cs
+++ b/Editor/ProjectEditorPrefsWindow.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using DUCK.Prefs;
+using DUCK.Utils.Editor.EditorGUIHelpers;
+using UnityEditor;
+
+namespace DUCK.Editor
+{
+	public class ProjectEditorPrefsWindow : EditorWindow
+	{
+		[MenuItem("DUCK/Project Editor Prefs")]
+		private static void CreateEditorPrefsWindow()
+		{
+			GetWindow<ProjectEditorPrefsWindow>("ProjectPrefs");
+		}
+
+		private void OnSelectionChange()
+		{
+			Repaint();
+		}
+
+		private void OnGUI()
+		{
+			var types = ProjectEditorPrefs.StoredPrefs;
+			foreach (var key in types.Keys.ToList())
+			{
+				var type = types[key];
+				var value = ProjectEditorPrefs.Get(key);
+
+				EditorGUI.BeginChangeCheck();
+				var newValue = EditorGUILayoutHelpers.FieldByType(key, value, type);
+				if (EditorGUI.EndChangeCheck())
+				{
+					ProjectEditorPrefs.Set(key, newValue, type);
+				}
+			}
+		}
+	}
+}

--- a/Editor/ProjectEditorPrefsWindow.cs.meta
+++ b/Editor/ProjectEditorPrefsWindow.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 2d67d29b9683e0b4e90e5c669b8b9ab3
+timeCreated: 1516982533
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prefs.meta
+++ b/Prefs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 00bc80cc94ee40b6b1c530da880a8384
+timeCreated: 1516986297

--- a/Prefs/ProjectEditorPrefs.cs
+++ b/Prefs/ProjectEditorPrefs.cs
@@ -9,7 +9,7 @@ namespace DUCK.Prefs
 	public static class ProjectEditorPrefs
 	{
 		public static Dictionary<string, Type> StoredPrefs { get; private set; }
-		private readonly static string projectName;
+		private static readonly string projectName;
 
 		static ProjectEditorPrefs()
 		{

--- a/Prefs/ProjectEditorPrefs.cs
+++ b/Prefs/ProjectEditorPrefs.cs
@@ -90,15 +90,15 @@ namespace DUCK.Prefs
 			{
 				EditorPrefs.SetString(key, (string)value);
 			}
-			if (type == typeof(bool))
+			else if (type == typeof(bool))
 			{
 				EditorPrefs.SetBool(key, (bool)value);
 			}
-			if (type == typeof(int))
+			else if (type == typeof(int))
 			{
 				 EditorPrefs.SetInt(key, (int)value);
 			}
-			if (type == typeof(float))
+			else if (type == typeof(float))
 			{
 				 EditorPrefs.SetFloat(key, (float)value);
 			}

--- a/Prefs/ProjectEditorPrefs.cs
+++ b/Prefs/ProjectEditorPrefs.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+#if UNITY_EDITOR
+namespace DUCK.Prefs
+{
+	public static class ProjectEditorPrefs
+	{
+		public static Dictionary<string, Type> StoredPrefs { get; private set; }
+		private readonly static string projectName;
+
+		static ProjectEditorPrefs()
+		{
+			projectName = Application.productName;
+			StoredPrefs = new Dictionary<string, Type>();
+		}
+
+		public static T Get<T>(string key, T defaultValue = default(T))
+		{
+			var storedKey = projectName + ":" + key;
+			if (StoredPrefs.ContainsKey(key))
+			{
+				return GetEditorPref<T>(storedKey);
+			}
+			// TODO: check editor prefs for existing value
+			else
+			{
+
+			}
+
+			Set<T>(key, defaultValue);
+			return defaultValue;
+		}
+
+		public static object Get(string key)
+		{
+			var storedKey = projectName + ":" + key;
+			if (StoredPrefs.ContainsKey(key))
+			{
+				return GetEditorPref(storedKey, StoredPrefs[key]);
+			}
+
+			throw new Exception("Key could not be found");
+		}
+
+		public static void Set<T>(string key, T value)
+		{
+			Set(key, value, typeof(T));
+		}
+
+		public static void Set(string key, object value, Type type)
+		{
+			var storedKey = projectName + ":" + key;
+			SetEditorPref(storedKey, value, type);
+			StoredPrefs[key] = type;
+		}
+
+		private static T GetEditorPref<T>(string key)
+		{
+			return (T) GetEditorPref(key, typeof(T));
+		}
+
+		private static object GetEditorPref(string key, Type type)
+		{
+			if (type == typeof(string))
+			{
+				return EditorPrefs.GetString(key);
+			}
+			if (type == typeof(bool))
+			{
+				return EditorPrefs.GetBool(key);
+			}
+			if (type == typeof(int))
+			{
+				return EditorPrefs.GetInt(key);
+			}
+			if (type == typeof(float))
+			{
+				return EditorPrefs.GetFloat(key);
+			}
+
+			return null;
+		}
+
+		private static void SetEditorPref(string key, object value, Type type)
+		{
+			if (type == typeof(string))
+			{
+				EditorPrefs.SetString(key, (string)value);
+			}
+			if (type == typeof(bool))
+			{
+				EditorPrefs.SetBool(key, (bool)value);
+			}
+			if (type == typeof(int))
+			{
+				 EditorPrefs.SetInt(key, (int)value);
+			}
+			if (type == typeof(float))
+			{
+				 EditorPrefs.SetFloat(key, (float)value);
+			}
+		}
+	}
+}
+#endif

--- a/Prefs/ProjectEditorPrefs.cs.meta
+++ b/Prefs/ProjectEditorPrefs.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c9f78da4f5804857bac472057395b66b
+timeCreated: 1516986306


### PR DESCRIPTION
Allows you to setup editor prefs that you can control via a tool window. These editor prefs can be used for anything editor time or editor runtime, such as drawing gizmos, skipping cutscenes etc...

EG: 
```
private void OnDrawGizmos()
{
	if (ProjectEditorPrefs.Get<bool>("drawMyFancyGizmos"))
	{
		Gizmos.color = Color.cyan;
		Gizmos.DrawCube(transform.position, new Vector3(3, 2, 3));
	}
}
```
![image](https://user-images.githubusercontent.com/5612566/35516973-1720a368-0505-11e8-8c83-d832ddca6a6b.png)


