### PR TITLE
Fixed bug with update list, and added unit tests

### DIFF
--- a/Utils/Editor/UpdateListTests.cs
+++ b/Utils/Editor/UpdateListTests.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using DUCK.Utils;
+using NUnit.Framework;
+
+namespace DUCK.Utils.Editor
+{
+	[TestFixture]
+	public class UpdateListTest
+	{
+		[Test]
+		public void ExpectConstructorNotToThrow()
+		{
+			Assert.DoesNotThrow(() =>
+			{
+				new UpdateList();
+			});
+		}
+
+		[Test]
+		public void ExpectAddedFunctionToBeCalledWhenUpdated()
+		{
+			var wasCalled = false;
+			Action<float> func = dt =>
+			{
+				wasCalled = true;
+			};
+
+			var updateList = new UpdateList();
+			updateList.Add(func);
+			Assert.IsFalse(wasCalled);
+			updateList.Update(0f);
+			Assert.IsTrue(wasCalled);
+		}
+
+		[Test]
+		public void ExpectAddToThrowIfFunctionIsAlreadyAdded()
+		{
+			Action<float> func = dt => {};
+			var updateList = new UpdateList();
+			updateList.Add(func);
+			Assert.Throws<Exception>(() =>
+			{
+				updateList.Add(func);
+			});
+		}
+
+		[Test]
+		public void ExpectContainsToReturnTrueOnlyIfFunctionWasAdded()
+		{
+			Action<float> func = dt => {};
+			var updateList = new UpdateList();
+			Assert.IsFalse(updateList.Contains(func));
+			updateList.Add(func);
+			Assert.IsTrue(updateList.Contains(func));
+		}
+
+		[Test]
+		public void ExpectRemoveToThrowIfFunctionWasNotFound()
+		{
+			Action<float> func = dt => {};
+			var updateList = new UpdateList();
+
+			Assert.Throws<Exception>(() =>
+			{
+				updateList.Remove(func);
+			});
+		}
+
+		[Test]
+		public void ExpectFunctionToNotBeCalledIfRemoveWasCalled()
+		{
+			var wasCalled = false;
+			Action<float> func = dt =>
+			{
+				wasCalled = true;
+			};
+
+			var updateList = new UpdateList();
+			updateList.Add(func);
+			Assert.IsFalse(wasCalled);
+			updateList.Remove(func);
+			Assert.IsFalse(wasCalled);
+
+			updateList.Update(0f);
+			Assert.IsFalse(wasCalled);
+		}
+
+		[Test]
+		public void ExpectContainsToReturnFalseAfterRemoveWasCalled()
+		{
+			Action<float> func = dt => { };
+			var updateList = new UpdateList();
+			updateList.Add(func);
+			updateList.Remove(func);
+			Assert.IsFalse(updateList.Contains(func));
+		}
+
+		[Test]
+		public void ExpectContainsToReturnFalseAfterRemoveWasCalledDuringFrame()
+		{
+			// we have to create another ref to the function so we can self remove within closure
+			Action<float> funcRef = null;
+
+			var updateList = new UpdateList();
+
+			Action<float> func = dt =>
+			{
+				updateList.Remove(funcRef);
+
+				Assert.IsFalse(updateList.Contains(funcRef));
+			};
+
+			funcRef = func;
+
+			updateList.Add(funcRef);
+		}
+
+		[Test]
+		public void ExpectUpdateToPassDeltaTimeToAllFunctions()
+		{
+			const float dtParam = 0.112f;
+
+			Action<float> func = dt =>
+			{
+				Assert.AreEqual(dt, dtParam);
+			};
+
+			var updateList = new UpdateList();
+			updateList.Add(func);
+			updateList.Update(dtParam);
+		}
+
+		[Test]
+		public void TestPreviousKnownBreakingEdgecases()
+		{
+			var updateList = new UpdateList();
+
+			// we have to create another ref to the functions so we can self remove within closures
+			Action<float> func2 = null;
+			Action<float> func0 = null;
+
+			Action<float> update2 = dt =>
+			{
+				// Do nothing special
+			};
+
+			Action<float> update1 = dt =>
+			{
+				updateList.Remove(func2);
+			};
+
+			Action<float> update0 = dt =>
+			{
+				updateList.Remove(func0);
+			};
+
+			func2 = update2;
+			func0 = update0;
+
+			updateList.Add(update0);
+			updateList.Add(update1);
+			updateList.Add(update2);
+
+			updateList.Update(0f);
+
+			Assert.IsFalse(updateList.Contains(update0));
+			Assert.IsTrue(updateList.Contains(update1));
+			Assert.IsFalse(updateList.Contains(update2));
+
+			// now dead test that index 2 is not marked as dead. by adding new updates, running them and checking they still exist
+			updateList.Remove(update1);
+
+			Action<float> update3Index0 = dt => { };
+			Action<float> update4Index1 = dt => { };
+			Action<float> update5Index2 = dt => { };
+
+
+			updateList.Add(update3Index0);
+			updateList.Add(update4Index1);
+			updateList.Add(update5Index2);
+
+			updateList.Update(0f);
+
+			Assert.IsTrue(updateList.Contains(update3Index0));
+			Assert.IsTrue(updateList.Contains(update4Index1));
+			Assert.IsTrue(updateList.Contains(update5Index2));
+		}
+	}
+}

--- a/Utils/Editor/UpdateListTests.cs
+++ b/Utils/Editor/UpdateListTests.cs
@@ -113,6 +113,8 @@ namespace DUCK.Utils.Editor
 			funcRef = func;
 
 			updateList.Add(funcRef);
+
+			updateList.Update(0f);
 		}
 
 		[Test]

--- a/Utils/Editor/UpdateListTests.cs
+++ b/Utils/Editor/UpdateListTests.cs
@@ -116,6 +116,26 @@ namespace DUCK.Utils.Editor
 		}
 
 		[Test]
+		public void ExpectRemoveAndReAddWithinAnUpdateLoopToNotRemove()
+		{
+			var updateList = new UpdateList();
+
+			Action<float> func2 = dt => { };
+			Action<float> func1 = dt =>
+			{
+				updateList.Remove(func2);
+				updateList.Add(func2);
+			};
+
+			updateList.Add(func1);
+			updateList.Add(func2);
+
+			updateList.Update(0f);
+
+			Assert.IsTrue(updateList.Contains(func2));
+		}
+
+		[Test]
 		public void ExpectUpdateToPassDeltaTimeToAllFunctions()
 		{
 			const float dtParam = 0.112f;

--- a/Utils/Editor/UpdateListTests.cs.meta
+++ b/Utils/Editor/UpdateListTests.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 167436b6f9ef1224fb78d79cdf45df34
+timeCreated: 1520606099
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Utils/UpdateList.cs
+++ b/Utils/UpdateList.cs
@@ -24,8 +24,16 @@ namespace DUCK.Utils
 
 		public void Add(Action<float> updateFunction)
 		{
-			if (updateFunctions.Contains(updateFunction))
+			var index = updateFunctions.IndexOf(updateFunction);
+			if (index >= 0)
 			{
+				// if the function exists but it's marked as dead we should, unmark it (to re add it)
+				if (deadFunctionIndices.Contains(index))
+				{
+					deadFunctionIndices.Remove(index);
+					return;
+				}
+
 				throw new Exception("Cannot add the given function. It is already in the list");
 			}
 

--- a/Utils/UpdateList.cs
+++ b/Utils/UpdateList.cs
@@ -16,12 +16,22 @@ namespace DUCK.Utils
 
 		private bool isUpdating;
 
+		/// <summary>
+		/// Returns true if the update list contains this function
+		/// </summary>
+		/// <param name="updateFunction">The update function to test for the presence of</param>
+		/// <returns>True if the function is in the update list, false if not</returns>
 		public bool Contains(Action<float> updateFunction)
 		{
 			var index = updateFunctions.IndexOf(updateFunction);
 			return index != -1 && !deadFunctionIndices.Contains(index);
 		}
 
+		/// <summary>
+		/// Adds the given function to the update list. It must not already be added.
+		/// </summary>
+		/// <param name="updateFunction">The update function to add to the update list</param>
+		/// <exception cref="Exception">Throws an Exception if the function was already added</exception>
 		public void Add(Action<float> updateFunction)
 		{
 			var index = updateFunctions.IndexOf(updateFunction);
@@ -40,6 +50,11 @@ namespace DUCK.Utils
 			updateFunctions.Add(updateFunction);
 		}
 
+		/// <summary>
+		/// Removes the given update function from the update list
+		/// </summary>
+		/// <param name="updateFunction">The update function to remove from the list</param>
+		/// <exception cref="Exception">Throws if the given update function was not in the list</exception>
 		public void Remove(Action<float> updateFunction)
 		{
 			var index = updateFunctions.IndexOf(updateFunction);
@@ -63,6 +78,10 @@ namespace DUCK.Utils
 			}
 		}
 
+		/// <summary>
+		/// Updtes all functions in the list in descending order.
+		/// </summary>
+		/// <param name="dt">The amount of delta time to be passed into each function.</param>
 		public void Update(float dt)
 		{
 			isUpdating = true;


### PR DESCRIPTION

## Background + Bug description + Reproduction

The bug is that some animations appear to not play. In actual fact they begin but never complete.
The problem is within the system that updates the animations, the AnimationDriver, or more specifically the update list implementation within. The update list is designed to be highly optimized and an abstracted enough to be used to update anything, not just a list of animations. It's more optimal than relying on several monobehaviour updates.

### Cause
The cause is due to the logic that deals with removal of update functions during an update loop. The logic specified that if we attempt to remove an update function, in most circumstances we mark it as dead by adding it's index to a list of deadFunctionIndices, however, if we were currently updating the function we wish to remove we would just remove it instantly.

### Reproduction
The simplest reproduction is an update list with 3 update functions added, which remove other functions

1. Start with an UpdateList with 3 updates (0, 1 and 2)
2. Update the list, the update list implementation updates in reverse order
3. Update `function2` - does nothing special
4. Update `function1` - removes `function2` - it gets marked as dead `deadFunctionIndices = [2]`
5. Update `function0` - removes `function0` - it gets removed instantly, which moves `function2` + `function1` down and index.
6. At the end of the frame we iterate backwards through each index of our update list, any that are marked as dead will be removed. In this case we start at index 1 and conclude with index 0. index 2 is marked as dead and never removed, this will only be removed at such times as the update list grows to that length.

In terms of animations this happens when the completion of one animation triggers another to be aborted, if the aborted one has a higher index in the AnimationDriver's update list. it will be marked as dead. This is fine until another animation is completed later on in the same frame (a lower indexed update function), which shrinks the list and the dead index is now out of range. The dead function indices would remain until the list grows big enough (more animations are played simultaneously). Those new animations would be updated for 1 frame and then removed, never completing and causing them to be stalled.

### The fix
There are several ways to fix this, but i went for the cause. Removing the instant removal. Now during an update any removals are marked as dead. We do not manipulate the update list during the loop, this is dangerous since we are using indices to mark things as dead. This ensures the 2nd loop (to remove anythin marked as dead), will be identical to the first loop that calls the udpate functions.

Other solutions involved different implementations or just making sure to delete all dead function indices on the end of the frame. But most of the others seemed like treatment rather than prevention. At the end of the day we should never get out of range dead indices.

## Tests and other considerations
I have added unit tests to test the basic functionality as well as adding a contains function. I have increased the level of erroring to throws if an invalid operation is performed. Before this was warnings/silent failing. I'm interested in feedback on this.

## Requirements
- [ ] Pull Request Approvals
- [ ] Feedback on error handling
- [ ] Tested on real project
- [ ] Feedback on implementation
- [ ] Feedback on unit tests