### PR TITLE
Dev tween abort

### DIFF
--- a/Tween/AnimationCollection.cs
+++ b/Tween/AnimationCollection.cs
@@ -37,7 +37,7 @@ namespace DUCK.Tween
 		/// </summary>
 		/// <param name="onComplete">An optional callback invoked when the AnimationCollection is complete</param>
 		/// <param name="onAbort">An optional callback invoked if the AnimationCollection is aborted</param>
-		public override void Play(Action onComplete = null, Action onAbort = null)
+		public override void Play(Action onComplete, Action onAbort = null)
 		{
 			base.Play(onComplete, onAbort);
 			NumberOfAnimationsCompleted = 0;
@@ -49,11 +49,11 @@ namespace DUCK.Tween
 		/// </summary>
 		public override void Abort()
 		{
+			base.Abort();
 			foreach (var animation in Animations)
 			{
 				animation.Abort();
 			}
-			base.Abort();
 		}
 
 		/// <summary>

--- a/Tween/AnimationCollection.cs
+++ b/Tween/AnimationCollection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace DUCK.Tween
 {
@@ -39,6 +40,12 @@ namespace DUCK.Tween
 		/// <param name="onAbort">An optional callback invoked if the AnimationCollection is aborted</param>
 		public override void Play(Action onComplete, Action onAbort = null)
 		{
+			if (!IsValid)
+			{
+				Debug.LogError("Invalid Animation Collection -- It's Empty!");
+				return;
+			}
+
 			base.Play(onComplete, onAbort);
 			NumberOfAnimationsCompleted = 0;
 			PlayQueuedAnimations();

--- a/Tween/AnimationCollection.cs
+++ b/Tween/AnimationCollection.cs
@@ -35,7 +35,7 @@ namespace DUCK.Tween
 		/// <summary>
 		/// Starts playback of the AnimationCollection starting at the first animation
 		/// </summary>
-		/// <param name="onComplete">An optional callback invoked when the AnimationCollection is complete</param>
+		/// <param name="onComplete">A callback invoked when the AnimationCollection is complete</param>
 		/// <param name="onAbort">An optional callback invoked if the AnimationCollection is aborted</param>
 		public override void Play(Action onComplete, Action onAbort = null)
 		{

--- a/Tween/DelegateAnimation.cs
+++ b/Tween/DelegateAnimation.cs
@@ -119,7 +119,7 @@ namespace DUCK.Tween
 			this.animationCreationFunction = animationCreationFunction;
 		}
 
-		public override void Play(Action onComplete = null, Action onAbort = null)
+		public override void Play(Action onComplete, Action onAbort = null)
 		{
 			base.Play(onComplete, onAbort);
 

--- a/Tween/ParalleledAnimation.cs
+++ b/Tween/ParalleledAnimation.cs
@@ -13,13 +13,17 @@
 
 			if (Animations.Count > 0)
 			{
-				Animations.ForEach(animation => animation.Play(HandleEachAnimationCompleted, () =>
+				for (var i = 0; i < Animations.Count; ++i)
 				{
-					if (!animation.IsValid)
+					var animation = Animations[i];
+					animation.Play(HandleEachAnimationCompleted, () =>
 					{
-						Animations.Remove(animation);
-					}
-				}));
+						if (IsPlaying && !animation.IsValid)
+						{
+							Animations.Remove(animation);
+						}
+					});
+				}
 			}
 			// In case of all animations have been removed
 			else

--- a/Tween/ParalleledAnimation.cs
+++ b/Tween/ParalleledAnimation.cs
@@ -1,4 +1,6 @@
-﻿namespace DUCK.Tween
+﻿using UnityEngine;
+
+namespace DUCK.Tween
 {
 	/// <summary>
 	/// ParalleledAnimation is used to play a set of animations in parallel.
@@ -9,25 +11,29 @@
 	{
 		protected override void PlayQueuedAnimations()
 		{
-			Animations.RemoveAll(animation => !animation.IsValid);
-
-			if (Animations.Count > 0)
+			for (var i = Animations.Count - 1; i >= 0; --i)
 			{
-				for (var i = 0; i < Animations.Count; ++i)
+				var animation = Animations[i];
+				if (animation.IsValid)
 				{
-					var animation = Animations[i];
 					animation.Play(HandleEachAnimationCompleted, () =>
 					{
 						if (IsPlaying && !animation.IsValid)
 						{
-							Animations.Remove(animation);
+							RemoveInvalidAnimation(animation);
 						}
 					});
 				}
+				else
+				{
+					RemoveInvalidAnimation(animation);
+				}
 			}
-			// In case of all animations have been removed
-			else
+
+			// All animations have been removed
+			if (Animations.Count == 0)
 			{
+				Debug.LogError("Aborting Parallelled Animation -- all animations are invalid!");
 				Abort();
 			}
 		}
@@ -39,6 +45,12 @@
 			{
 				NotifyAnimationComplete();
 			}
+		}
+
+		private void RemoveInvalidAnimation(AbstractAnimation targetAnimation)
+		{
+			Debug.LogError("Removed an invalid animation from the Paralleled Queue!");
+			Animations.Remove(targetAnimation);
 		}
 	}
 }

--- a/Tween/SequencedAnimation.cs
+++ b/Tween/SequencedAnimation.cs
@@ -18,6 +18,13 @@ namespace DUCK.Tween
 
 		protected override void PlayQueuedAnimations()
 		{
+			// All animations have been removed
+			if (Animations.Count == 0)
+			{
+				Debug.LogError("Aborting Sequenced Animation -- all animations are invalid!");
+				Abort();
+			}
+
 			if (NumberOfAnimationsCompleted < Animations.Count)
 			{
 				var nextAnimation = Animations[NumberOfAnimationsCompleted];
@@ -27,15 +34,13 @@ namespace DUCK.Tween
 					{
 						if (IsPlaying && !nextAnimation.IsValid)
 						{
-							Animations.Remove(nextAnimation);
-							PlayQueuedAnimations();
+							RemoveInvalidAnimation(nextAnimation);
 						}
 					});
 				}
 				else
 				{
-					Animations.Remove(nextAnimation);
-					PlayQueuedAnimations();
+					RemoveInvalidAnimation(nextAnimation);
 				}
 			}
 			else if (NumberOfAnimationsCompleted == Animations.Count)
@@ -47,6 +52,13 @@ namespace DUCK.Tween
 		private void HandleCurrentAnimationCompleted()
 		{
 			NumberOfAnimationsCompleted++;
+			PlayQueuedAnimations();
+		}
+
+		private void RemoveInvalidAnimation(AbstractAnimation targetAnimation)
+		{
+			Debug.LogError("Removed an invalid animation from the Sequenced Queue!");
+			Animations.Remove(targetAnimation);
 			PlayQueuedAnimations();
 		}
 

--- a/Tween/SequencedAnimation.cs
+++ b/Tween/SequencedAnimation.cs
@@ -25,7 +25,7 @@ namespace DUCK.Tween
 				{
 					nextAnimation.Play(HandleCurrentAnimationCompleted, () =>
 					{
-						if (!nextAnimation.IsValid)
+						if (IsPlaying && !nextAnimation.IsValid)
 						{
 							Animations.Remove(nextAnimation);
 							PlayQueuedAnimations();

--- a/Tween/TimedAnimation.cs
+++ b/Tween/TimedAnimation.cs
@@ -121,7 +121,10 @@ namespace DUCK.Tween
 
 		public override void Abort()
 		{
-			AnimationDriver.Remove(Update);
+			if (IsPlaying)
+			{
+				AnimationDriver.Remove(Update);
+			}
 			base.Abort();
 		}
 

--- a/Utils/Editor/Tests/AsyncTaskListTest.cs
+++ b/Utils/Editor/Tests/AsyncTaskListTest.cs
@@ -12,7 +12,7 @@ namespace DUCK.Utils.Editor.Tests
 		{
 			Assert.DoesNotThrow(() =>
 			{
-				var tasks = new AsyncTaskList();
+				new AsyncTaskList();
 			});
 		}
 


### PR DESCRIPTION
- Fixed an issue that aborting an invalid animation collection will crash.
- Added a guard for aborting a non-playing animation.