### PR TITLE
Thread-safe DebugMenuLog

### DIFF
--- a/DebugMenu/DebugMenuLog.cs
+++ b/DebugMenu/DebugMenuLog.cs
@@ -74,6 +74,10 @@ namespace DUCK.DebugMenu
 			Log(text, LogType.Error);
 		}
 
+		/// <summary>
+		/// The logs are passed back to the main thread through a queue as instantiating the new log
+		/// must be done on the main thread, however the queue itself is not properly concurrent.
+		/// </summary>
 		private static void Log(string text, LogType logType)
 		{
 			if (instance == null) return;


### PR DESCRIPTION
Pass pending logs back to the main thread. Unity's Debug.Log is thread-safe so it made sense for this to be too. I didn't modify the `Clear` function to be thread safe from code as it's only called from the button click which will always be safe.