### PR TITLE
Fixed tests failing due to DoNotDestroyOnLoad

### DIFF
--- a/AudioSystem/AudioSystem.cs
+++ b/AudioSystem/AudioSystem.cs
@@ -130,7 +130,9 @@ namespace DUCK.AudioSystem
 				throw new Exception("You should only have 1 AudioSystem in your game! " + name);
 			}
 			Instance = this;
-			if (transform.parent == null)
+
+			//NOTE When running tests you cannot use DontDestroyOnLoad in editor mode
+			if (transform.parent == null && Application.isPlaying)
 			{
 				DontDestroyOnLoad(this);
 			}

--- a/DebugMenu/DebugMenu.cs
+++ b/DebugMenu/DebugMenu.cs
@@ -66,7 +66,11 @@ namespace DUCK.DebugMenu
 
 			logPage.Initialise();
 
-			DontDestroyOnLoad(this);
+			//NOTE When running tests you cannot use DontDestroyOnLoad in editor mode
+			if (Application.isPlaying)
+			{
+				DontDestroyOnLoad(this);
+			}
 		}
 
 		private void Start()

--- a/Tween/AnimationDriver.cs
+++ b/Tween/AnimationDriver.cs
@@ -32,7 +32,11 @@ namespace DUCK.Tween
 		private static DefaultAnimationDriver CreateInstance()
 		{
 			var gameObject = new GameObject { hideFlags = HideFlags.HideInHierarchy };
-			DontDestroyOnLoad(gameObject);
+			//NOTE When running tests you cannot use DontDestroyOnLoad in editor mode
+			if (Application.isPlaying)
+			{
+				DontDestroyOnLoad(gameObject);
+			}
 			return instance = gameObject.AddComponent<DefaultAnimationDriver>();
 		}
 

--- a/Utils/MonoBehaviourService.cs
+++ b/Utils/MonoBehaviourService.cs
@@ -77,7 +77,11 @@ namespace DUCK.Utils
 		private MonoBehaviourService()
 		{
 			var gameObject = new GameObject { hideFlags = HideFlags.HideInHierarchy };
-			Object.DontDestroyOnLoad(gameObject);
+			//NOTE When running tests you cannot use DontDestroyOnLoad in editor mode
+			if (Application.isPlaying)
+			{
+				Object.DontDestroyOnLoad(gameObject);
+			}
 			serviceInstance = gameObject.AddComponent<MonoBehaviourServiceBehaviour>();
 
 			serviceInstance.OnLevelLoaded += () => { OnLevelLoaded.SafeInvoke(); };


### PR DESCRIPTION
The unity editor does not allow a function call of DoNotDestroyOnLoad at editor time. When writing tests that spawn a view that uses DUCK tween for example this function is called and causes the test to fail.