### PR TITLE
ArgsList: added support for enums + scriptable objects

### DIFF
--- a/Serialization/ArgsList.Serialization.cs
+++ b/Serialization/ArgsList.Serialization.cs
@@ -10,6 +10,7 @@ namespace DUCK.Serialization
 	{
 		private const string COMPONENT_PREFIX = "c:";
 		private const string ENUM_PREFIX = "e:";
+		private const string SCRIPTABLE_OBJECT_PREFIX = "so:";
 
 		[SerializeField]
 		private string[] typeOrder;
@@ -41,6 +42,9 @@ namespace DUCK.Serialization
 		[SerializeField]
 		private Color[] colorArgs;
 
+		[SerializeField]
+		private ScriptableObject[] scriptableObjectArgs;
+
 		public void OnBeforeSerialize()
 		{
 			if (argTypes == null) return;
@@ -57,6 +61,10 @@ namespace DUCK.Serialization
 				else if (t.IsSubclassOf(typeof(Enum)))
 				{
 					t = typeof(int);
+				}
+				else if (t.IsSubclassOf(typeof(ScriptableObject)))
+				{
+					t = typeof(ScriptableObject);
 				}
 				else if (argLists.ContainsKey(t))
 				{
@@ -80,6 +88,12 @@ namespace DUCK.Serialization
 					var arg = args[i];
 					list.Add(arg);
 					typeOrderList.Add(ENUM_PREFIX + argType.FullName);
+				}
+				else if (argType.IsSubclassOf(typeof(ScriptableObject)))
+				{
+					var arg = args[i];
+					list.Add(arg);
+					typeOrderList.Add(SCRIPTABLE_OBJECT_PREFIX + argType.FullName);
 				}
 				else
 				{
@@ -141,6 +155,20 @@ namespace DUCK.Serialization
 					argType = enumTypes[typeName];
 					localArgTypes.Add(argType);
 					list = serializedLists[typeof(int).FullName];
+				}
+				else if (typeName.StartsWith(SCRIPTABLE_OBJECT_PREFIX))
+				{
+					// strip off prefix
+					typeName = typeName.Replace(SCRIPTABLE_OBJECT_PREFIX, "");
+
+					if (!scriptableObjectTypes.ContainsKey(typeName))
+					{
+						throw new Exception("ArgsList cannot deserialize ScriptableObject item of type: " + typeName + ", it was not found in the assemblies");
+					}
+
+					argType = scriptableObjectTypes[typeName];
+					localArgTypes.Add(argType);
+					list = serializedLists[typeof(ScriptableObject).FullName];
 				}
 				else
 				{

--- a/Serialization/ArgsList.Serialization.cs
+++ b/Serialization/ArgsList.Serialization.cs
@@ -76,28 +76,24 @@ namespace DUCK.Serialization
 			for (int i = 0; i < argTypes.Count; i++)
 			{
 				var argType = argTypes[i];
+				var arg = args[i];
 				var list = lazyGetList(argType);
+				list.Add(arg);
+
 				if (argType.IsSubclassOf(typeof(Component)))
 				{
-					var arg = args[i];
-					list.Add(arg);
 					typeOrderList.Add(COMPONENT_PREFIX + argType.FullName);
 				}
 				else if (argType.IsSubclassOf(typeof(Enum)))
 				{
-					var arg = args[i];
-					list.Add(arg);
 					typeOrderList.Add(ENUM_PREFIX + argType.FullName);
 				}
 				else if (argType.IsSubclassOf(typeof(ScriptableObject)))
 				{
-					var arg = args[i];
-					list.Add(arg);
 					typeOrderList.Add(SCRIPTABLE_OBJECT_PREFIX + argType.FullName);
 				}
 				else
 				{
-					list.Add(args[i]);
 					typeOrderList.Add(argType.FullName);
 				}
 			}
@@ -225,7 +221,11 @@ namespace DUCK.Serialization
 			{
 				return new SupportedType(
 					typeof(T),
-					i => (getList(i) ?? new T[0]).Cast<object>().ToList(),
+					i =>
+					{
+						var list = getList(i);
+						return list != null ? list.Cast<object>().ToList() : new List<object>();
+					},
 					(i, v) => setList(i, v.Cast<T>().ToArray()));
 			}
 		}

--- a/Serialization/ArgsList.Serialization.cs
+++ b/Serialization/ArgsList.Serialization.cs
@@ -225,7 +225,7 @@ namespace DUCK.Serialization
 			{
 				return new SupportedType(
 					typeof(T),
-					i => getList(i).Cast<object>().ToList(),
+					i => (getList(i) ?? new T[0]).Cast<object>().ToList(),
 					(i, v) => setList(i, v.Cast<T>().ToArray()));
 			}
 		}

--- a/Serialization/ArgsList.cs
+++ b/Serialization/ArgsList.cs
@@ -47,40 +47,22 @@ namespace DUCK.Serialization
 			enumTypes = new Dictionary<string, Type>();
 			scriptableObjectTypes = new Dictionary<string, Type>();
 
-			// Get every type that extends component
-			var assemblies = new []
-			{
-				// Project assembly
-				Assembly.GetExecutingAssembly(),
-				// UnityEngine Assembly
-				typeof(Component).Assembly,
-				// UnityEngine.UI Assembly
-				typeof(Graphic).Assembly,
-			};
+			var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
 			foreach (var type in assemblies.SelectMany(a => a.GetTypes()))
 			{
 				var fullTypeName = type.FullName;
 				if (type.IsSubclassOf(typeof(Component)))
 				{
-					if (!componentTypes.ContainsKey(fullTypeName))
-					{
-						componentTypes.Add(fullTypeName, type);
-					}
+					componentTypes[fullTypeName] = type;
 				}
 				else if (type.IsSubclassOf(typeof(Enum)))
 				{
-					if (!enumTypes.ContainsKey(fullTypeName))
-					{
-						enumTypes.Add(fullTypeName, type);
-					}
+					enumTypes[fullTypeName] = type;
 				}
 				else if (type.IsSubclassOf(typeof(ScriptableObject)))
 				{
-					if (!scriptableObjectTypes.ContainsKey(fullTypeName))
-					{
-						scriptableObjectTypes.Add(fullTypeName, type);
-					}
+					scriptableObjectTypes[fullTypeName] = type;
 				}
 			}
 		}

--- a/Serialization/ArgsList.cs
+++ b/Serialization/ArgsList.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace DUCK.Serialization
 {

--- a/Serialization/ArgsList.cs
+++ b/Serialization/ArgsList.cs
@@ -15,6 +15,7 @@ namespace DUCK.Serialization
 		{
 			return supportedTypesArray.Contains(type) ||
 				type.IsSubclassOf(typeof(Component)) ||
+				type.IsSubclassOf(typeof(ScriptableObject)) ||
 				type.IsSubclassOf(typeof(Enum));
 		}
 
@@ -22,6 +23,7 @@ namespace DUCK.Serialization
 		private static readonly Type[] supportedTypesArray;
 		private static readonly Dictionary<string, Type> componentTypes;
 		private static readonly Dictionary<string, Type> enumTypes;
+		private static readonly Dictionary<string, Type> scriptableObjectTypes;
 
 		static ArgsList()
 		{
@@ -36,12 +38,14 @@ namespace DUCK.Serialization
 				SupportedType.Create(i => i.vector3Args, (i, v) => i.vector3Args = v),
 				SupportedType.Create(i => i.vector4Args, (i, v) => i.vector4Args = v),
 				SupportedType.Create(i => i.colorArgs, (i, v) => i.colorArgs = v),
+				SupportedType.Create(i => i.scriptableObjectArgs, (i, v) => i.scriptableObjectArgs = v),
 			};
 
 			supportedTypesArray = supportedTypesList.Select(t => t.Type).ToArray();
 			supportedTypes = supportedTypesList.ToDictionary(t => t.Type.FullName, t => t);
 			componentTypes = new Dictionary<string, Type>();
 			enumTypes = new Dictionary<string, Type>();
+			scriptableObjectTypes = new Dictionary<string, Type>();
 
 			// Get every type that extends component
 			var assemblies = new []
@@ -69,6 +73,13 @@ namespace DUCK.Serialization
 					if (!enumTypes.ContainsKey(fullTypeName))
 					{
 						enumTypes.Add(fullTypeName, type);
+					}
+				}
+				else if (type.IsSubclassOf(typeof(ScriptableObject)))
+				{
+					if (!scriptableObjectTypes.ContainsKey(fullTypeName))
+					{
+						scriptableObjectTypes.Add(fullTypeName, type);
 					}
 				}
 			}

--- a/Serialization/Editor/ArgsListTests.cs
+++ b/Serialization/Editor/ArgsListTests.cs
@@ -438,6 +438,26 @@ namespace DUCK.Serialization.Editor
 		}
 
 		[Test]
+		public void ExpectEnumSerializationToBeSupported()
+		{
+			var argsList = new ArgsList();
+
+			// test that it doesn't throw when specifying the type
+
+			Assert.DoesNotThrow(() => argsList.SetTypes(new List<Type> {typeof(GradientMode)}));
+
+			// Add some data, serialize and deserialize
+			var value = GradientMode.Fixed;
+			argsList.Set(0, value);
+			var json = JsonUtility.ToJson(argsList);
+			var resultArgsList = JsonUtility.FromJson<ArgsList>(json);
+			var result = resultArgsList.Get<GradientMode>(0);
+
+			// Now test the value is what it should be
+			Assert.AreEqual(value, result);
+		}
+
+		[Test]
 		public void ExpectSerializationOfMultipleTypesToBeSupported()
 		{
 			var argsList = new ArgsList();

--- a/Serialization/Editor/ArgsListTests.cs
+++ b/Serialization/Editor/ArgsListTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using DUCK.Tween.Serialization;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.UI;
@@ -452,6 +453,26 @@ namespace DUCK.Serialization.Editor
 			var json = JsonUtility.ToJson(argsList);
 			var resultArgsList = JsonUtility.FromJson<ArgsList>(json);
 			var result = resultArgsList.Get<GradientMode>(0);
+
+			// Now test the value is what it should be
+			Assert.AreEqual(value, result);
+		}
+
+		[Test]
+		public void ExpectScriptableObjectSerializationToBeSupported()
+		{
+			var argsList = new ArgsList();
+
+			// test that it doesn't throw when specifying the type
+			Assert.DoesNotThrow(() => argsList.SetTypes(new List<Type> {typeof(TweenConfig)}));
+
+			// Add some data, serialize and deserialize
+			var value = ScriptableObject.CreateInstance<TweenConfig>();
+			argsList.Set(0, value);
+
+			var json = JsonUtility.ToJson(argsList);
+			var resultArgsList = JsonUtility.FromJson<ArgsList>(json);
+			var result = resultArgsList.Get<TweenConfig>(0);
 
 			// Now test the value is what it should be
 			Assert.AreEqual(value, result);

--- a/Serialization/Editor/ArgsListTests.cs
+++ b/Serialization/Editor/ArgsListTests.cs
@@ -10,6 +10,14 @@ namespace DUCK.Serialization.Editor
 	[TestFixture]
 	public class ArgsListTests
 	{
+		public class TestScriptableObject : ScriptableObject{}
+
+		public enum TestEnum
+		{
+			A,
+			B
+		}
+
 		[Test]
 		public void ExpectConstructorNotToThrow()
 		{
@@ -445,14 +453,14 @@ namespace DUCK.Serialization.Editor
 
 			// test that it doesn't throw when specifying the type
 
-			Assert.DoesNotThrow(() => argsList.SetTypes(new List<Type> {typeof(GradientMode)}));
+			Assert.DoesNotThrow(() => argsList.SetTypes(new List<Type> {typeof(TestEnum)}));
 
 			// Add some data, serialize and deserialize
-			var value = GradientMode.Fixed;
+			var value = TestEnum.A;
 			argsList.Set(0, value);
 			var json = JsonUtility.ToJson(argsList);
 			var resultArgsList = JsonUtility.FromJson<ArgsList>(json);
-			var result = resultArgsList.Get<GradientMode>(0);
+			var result = resultArgsList.Get<TestEnum>(0);
 
 			// Now test the value is what it should be
 			Assert.AreEqual(value, result);
@@ -464,15 +472,15 @@ namespace DUCK.Serialization.Editor
 			var argsList = new ArgsList();
 
 			// test that it doesn't throw when specifying the type
-			Assert.DoesNotThrow(() => argsList.SetTypes(new List<Type> {typeof(TweenConfig)}));
+			Assert.DoesNotThrow(() => argsList.SetTypes(new List<Type> {typeof(TestScriptableObject)}));
 
 			// Add some data, serialize and deserialize
-			var value = ScriptableObject.CreateInstance<TweenConfig>();
+			var value = ScriptableObject.CreateInstance<TestScriptableObject>();
 			argsList.Set(0, value);
 
 			var json = JsonUtility.ToJson(argsList);
 			var resultArgsList = JsonUtility.FromJson<ArgsList>(json);
-			var result = resultArgsList.Get<TweenConfig>(0);
+			var result = resultArgsList.Get<TestScriptableObject>(0);
 
 			// Now test the value is what it should be
 			Assert.AreEqual(value, result);

--- a/Utils/Editor/EditorGUIHelpers/DrawFieldByTypes.cs
+++ b/Utils/Editor/EditorGUIHelpers/DrawFieldByTypes.cs
@@ -49,7 +49,7 @@ namespace DUCK.Utils.Editor.EditorGUIHelpers
 			// special case for enum fields
 			if (type.IsSubclassOf(typeof(Enum)))
 			{
-				return EditorGUILayout.EnumPopup(label, (Enum) obj);
+				return EditorGUILayout.EnumPopup(label, (Enum)Enum.ToObject(type, (int)obj));
 			}
 
 			// check we can deal with this type of field

--- a/Utils/Editor/EditorGUIHelpers/DrawFieldByTypes.cs
+++ b/Utils/Editor/EditorGUIHelpers/DrawFieldByTypes.cs
@@ -46,6 +46,12 @@ namespace DUCK.Utils.Editor.EditorGUIHelpers
 				return EditorGUILayout.ObjectField(label, (UnityEngine.Object) obj, type, true);
 			}
 
+			// special case for enum fields
+			if (type.IsSubclassOf(typeof(Enum)))
+			{
+				return EditorGUILayout.EnumPopup(label, (Enum) obj);
+			}
+
 			// check we can deal with this type of field
 			if (!drawerFunctions.ContainsKey(type))
 			{


### PR DESCRIPTION
This is something that I should have done a when I first made it, but now it's here. It includes tests.

Writing this has highlighted the need to refactor a little bit:

Before the code had to make exceptions for component subclasses. The exceptions were in quite a few places but it was only for one type. I didn't foresee that this would be such a common thing. Now subclass exceptions need to be made for Enums and ScriptableObjects too. 

I need a solution where I can easily add extra ones and customize behaviours in different places for each type.

I will look into this in a different PR