### PR TITLE
Fix: AudioFaders will complete if the clip ends before the fade ends

### DIFF
--- a/AudioSystem/AudioSystem.cs
+++ b/AudioSystem/AudioSystem.cs
@@ -77,7 +77,7 @@ namespace DUCK.AudioSystem
 
 				timer += dt;
 				channel.volume = Mathf.Lerp(from, to, timer / duration);
-				if (timer >= duration)
+				if (timer >= duration || !channel.isPlaying)
 				{
 					if (onComplete != null)
 					{


### PR DESCRIPTION
This is to fix the following issue:

1. audioConfig.FadeOut(1f) // fade the clip out over 1 second
2. Less 1 seconds later the clip reaches the end. but the fader will still continue reducing the volume
3. something else attempts to play, the AudioSystem requests a free channel. This does `channels.FirstOrDefault(source => !source.isPlaying);` It can return channel still being affected by a fader. meaning your new sound will be affected, usually resulting in it not being heard, since it's probably already mostly faded out.