### PR TITLE
AudioConfigSequence cleanup

### DIFF
--- a/AudioSystem/AudioConfigSequence.cs
+++ b/AudioSystem/AudioConfigSequence.cs
@@ -17,14 +17,25 @@ namespace DUCK.AudioSystem
 		}
 
 		private AudioConfig[] compositeAudioConfigs;
-		public IEnumerable<AudioConfig> GetAudioConfigs()
+		public AudioConfig[] AudioConfigs
 		{
-			if (compositeAudioConfigs == null)
+			get
 			{
-				compositeAudioConfigs = entries.Select(e => e.AudioConfig).ToArray();
-			}
+				if (compositeAudioConfigs == null)
+				{
+					compositeAudioConfigs = entries.Select(e => e.AudioConfig).ToArray();
+				}
 
-			return compositeAudioConfigs;
+				return compositeAudioConfigs;
+			}
+		}
+
+		public int Count
+		{
+			get
+			{
+				return AudioConfigs.Length;
+			}
 		}
 
 		[Serializable]
@@ -43,8 +54,8 @@ namespace DUCK.AudioSystem
 			private string clipIndexParameter;
 
 			[SerializeField]
-			private float postClipDelay;
-			public float PostClipDelay { get { return postClipDelay; } }
+			private float preClipDelay;
+			public float ClipDelay { get { return preClipDelay; } }
 
 			public AudioConfig AudioConfig { get { return audioConfig; } }
 
@@ -101,12 +112,12 @@ namespace DUCK.AudioSystem
 			return AudioConfig.RANDOM_CLIP;
 		}
 
-		public float GetPostClipDelay(int audioConfigIndex)
+		public float GetClipDelay(int audioConfigIndex)
 		{
 			var entry = GetEntry(audioConfigIndex);
 			if (entry != null)
 			{
-				return entry.PostClipDelay;
+				return entry.ClipDelay;
 			}
 
 			return 0f;

--- a/AudioSystem/AudioSystemExtension.cs
+++ b/AudioSystem/AudioSystemExtension.cs
@@ -164,15 +164,18 @@ namespace DUCK.AudioSystem
 		/// <param name="onComplete">The callback when the playback of all configs finished</param>
 		/// <returns>The channel (AudioSource) which the Audio System is using for the first clip in the sequence</returns>
 		public static AudioSource PlaySequence(this IEnumerable<AudioConfig> audioConfigs, float volume = 1f, Transform parent = null, 
-			Func<int, int> getClipId = null, Func<int, float> getClipDelay = null, Action onComplete = null, Action<int> onEachConfigPlayed = null)
+			Func<int, int> getClipId = null, Func<int, float> getClipDelay = null, 
+			Action onComplete = null, Action<int> onEachConfigPlayed = null, Action<Timer> onTimerStarted = null)
 		{
-			return PlaySequenceAtIndex(0, audioConfigs.GetEnumerator(), volume, parent, getClipId, getClipDelay, onComplete, onEachConfigPlayed);
+			return PlaySequenceAtIndex(0, audioConfigs.GetEnumerator(), volume, parent, getClipId, getClipDelay, 
+				onComplete, onEachConfigPlayed, onTimerStarted);
 		}
 
 		public static AudioSource PlaySequence(this AudioConfigSequence compositeConfig, float volume = 1f, Transform parent = null, 
-			Action onComplete = null, Action<int> onEachConfigPlayed = null)
+			Action onComplete = null, Action<int> onEachConfigPlayed = null, Action<Timer> onTimerStarted = null)
 		{
-			return PlaySequence(compositeConfig.GetAudioConfigs(), volume, parent, compositeConfig.GetClipIndex, compositeConfig.GetPostClipDelay, onComplete, onEachConfigPlayed);
+			return PlaySequence(compositeConfig.GetAudioConfigs(), volume, parent, compositeConfig.GetClipIndex, compositeConfig.GetPostClipDelay, 
+				onComplete, onEachConfigPlayed, onTimerStarted);
 		}
 
 		public static AudioSource PlaySequence(this AudioConfigSequence compositeConfig, Action onComplete = null)
@@ -181,7 +184,7 @@ namespace DUCK.AudioSystem
 		}
 
 		private static AudioSource PlaySequenceAtIndex(int index, IEnumerator<AudioConfig> enumerator, float volume, Transform parent = null, 
-			Func<int, int> getClipId = null, Func<int, float> getClipDelay = null, Action onComplete = null, Action<int> onEachConfigPlayed = null)
+			Func<int, int> getClipId = null, Func<int, float> getClipDelay = null, Action onComplete = null, Action<int> onEachConfigPlayed = null, Action<Timer> onTimerStarted = null)
 		{
 			Func<AudioSource> playNextConfig = () =>
 			{
@@ -207,7 +210,8 @@ namespace DUCK.AudioSystem
 			}
 			else
 			{
-				Timer.SetTimeout(delay, () => playNextConfig());
+				var timer = Timer.SetTimeout(delay, () => playNextConfig());
+				onTimerStarted.SafeInvoke(timer);
 				return null;
 			}
 		}

--- a/AudioSystem/Editor/AudioConfigSequenceEditor.cs
+++ b/AudioSystem/Editor/AudioConfigSequenceEditor.cs
@@ -45,8 +45,8 @@ namespace DUCK.AudioSystem.Editor
 				}
 				EditorGUILayout.EndHorizontal();
 
-				var postClipDelay = property.FindPropertyRelative("preClipDelay");
-				EditorGUILayout.PropertyField(postClipDelay);
+				var preClipDelay = property.FindPropertyRelative("preClipDelay");
+				EditorGUILayout.PropertyField(preClipDelay);
 			}
 			EditorGUILayout.EndVertical();
 		}

--- a/AudioSystem/Editor/AudioConfigSequenceEditor.cs
+++ b/AudioSystem/Editor/AudioConfigSequenceEditor.cs
@@ -45,7 +45,7 @@ namespace DUCK.AudioSystem.Editor
 				}
 				EditorGUILayout.EndHorizontal();
 
-				var postClipDelay = property.FindPropertyRelative("postClipDelay");
+				var postClipDelay = property.FindPropertyRelative("preClipDelay");
 				EditorGUILayout.PropertyField(postClipDelay);
 			}
 			EditorGUILayout.EndVertical();


### PR DESCRIPTION
Changed sequences to return configs, not the raw AudioSource objects, since these should be handled internally by the audio system